### PR TITLE
#57 - fix tray icon crashing

### DIFF
--- a/.github/workflows/01_build_test_publish.yaml
+++ b/.github/workflows/01_build_test_publish.yaml
@@ -148,11 +148,11 @@ jobs:
           path: ${{ env.PUBLISH_PATH }}/FancyMouse.WinUI3
 
       # where have the test result images gone?
-      - name: dotnet publish (winui3)
+      - name: directory listing
         if: always()
         working-directory: ${{ env.BUILD_PATH }}
         run: |
-          dir -recursive
+          dir -recurse -filter "*_actual.png"
 
       - name: upload test images
         if: always()

--- a/.github/workflows/01_build_test_publish.yaml
+++ b/.github/workflows/01_build_test_publish.yaml
@@ -149,6 +149,7 @@ jobs:
 
       # where have the test result images gone?
       - name: dotnet publish (winui3)
+        if: always()
         working-directory: ${{ env.BUILD_PATH }}
         run: |
           dir -recursive

--- a/.github/workflows/01_build_test_publish.yaml
+++ b/.github/workflows/01_build_test_publish.yaml
@@ -1,8 +1,8 @@
 name: "01 - Build, Test, Publish"
 
 on:
-  push:
-    # run on all commits
+  #push:
+  #  # run on all commits
   pull_request:
     # run on all pull requests
   workflow_dispatch:

--- a/.github/workflows/01_build_test_publish.yaml
+++ b/.github/workflows/01_build_test_publish.yaml
@@ -147,6 +147,12 @@ jobs:
           name: FancyMouse.WinUI3-v0.0.0-preview
           path: ${{ env.PUBLISH_PATH }}/FancyMouse.WinUI3
 
+      # where have the test result images gone?
+      - name: dotnet publish (winui3)
+        working-directory: ${{ env.BUILD_PATH }}
+        run: |
+          dir -recursive
+
       - name: upload test images
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/01_build_test_publish.yaml
+++ b/.github/workflows/01_build_test_publish.yaml
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-images
-          path: ${{ env.BUILD_PATH }}/FancyMouse.Common.UnitTests/${{ env.PLATFORM_NAME }}/${{ env.CONFIG_NAME }}/${{ env.TARGET_FRAMEWORK }}/*_actual.png
+          path: ${{ env.BUILD_PATH }}/FancyMouse.Common.UnitTests/bin/${{ env.PLATFORM_NAME }}/${{ env.CONFIG_NAME }}/${{ env.TARGET_FRAMEWORK }}/*_actual.png
 
       #- name: dotnet tool jb inspectcode
       #  working-directory: ${{ env.BUILD_PATH }}

--- a/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
@@ -44,6 +44,22 @@ public sealed class DrawingHelperTests
 
         public static IEnumerable<object[]> GetTestCases()
         {
+            // colors like "SystemColors.Highlight" can change between versions of windows,
+            // so we'll use hard-coded colors instead to reduce false test failures
+            var systemHighlight = Color.FromArgb(0, 120, 215);
+            var previewStyle = StyleHelper.BezelledPreviewStyle;
+            previewStyle = new(
+                canvasSize: previewStyle.CanvasSize,
+                canvasStyle: new(
+                    marginStyle: previewStyle.CanvasStyle.MarginStyle,
+                    borderStyle: previewStyle.CanvasStyle.BorderStyle.WithColor(systemHighlight),
+                    paddingStyle: previewStyle.CanvasStyle.PaddingStyle,
+                    backgroundStyle: previewStyle.CanvasStyle.BackgroundStyle
+                ),
+                screenStyle: previewStyle.ScreenStyle,
+                extraColors: previewStyle.ExtraColors
+            );
+
             // 4-grid
             var displayInfo = new DisplayInfo(
                 devices: new DeviceInfo[]
@@ -79,7 +95,7 @@ public sealed class DrawingHelperTests
             yield return new object[]
             {
                 new TestCase(
-                    previewStyle: StyleHelper.BezelledPreviewStyle,
+                    previewStyle: previewStyle,
                     displayInfo: displayInfo,
                     activatedScreen: displayInfo.Devices[0].Screens[0],
                     activatedLocation: new(x: 50, y: 50),
@@ -113,7 +129,7 @@ public sealed class DrawingHelperTests
             yield return new object[]
             {
                 new TestCase(
-                    previewStyle: StyleHelper.BezelledPreviewStyle,
+                    previewStyle: previewStyle,
                     displayInfo: displayInfo,
                     activatedScreen: displayInfo.Devices[0].Screens[0],
                     activatedLocation: new(x: 50, y: 50),

--- a/src/FancyMouse.Common/Helpers/TrayIcon.cs
+++ b/src/FancyMouse.Common/Helpers/TrayIcon.cs
@@ -23,6 +23,13 @@ public sealed class TrayIcon
 
     public TrayIcon()
     {
+        // cache the window proc delegate so it doesn't get garbage-collected
+        this.WndProc = this.WindowProc;
+    }
+
+    private WNDPROC WndProc
+    {
+        get;
     }
 
     private Icon? Icon
@@ -60,7 +67,7 @@ public sealed class TrayIcon
         var window = Win32Helper.User32.CreateMessageOnlyWindow(
             className: "FancyMouseTrayIconClass",
             windowName: "FancyMouseTrayIconWindow",
-            wndProc: this.TrayIconWndProc);
+            wndProc: this.WndProc);
         this.Window = window;
     }
 
@@ -124,7 +131,7 @@ public sealed class TrayIcon
         return icon;
     }
 
-    public LRESULT TrayIconWndProc(HWND hWnd, MESSAGE_TYPE msg, WPARAM wParam, LPARAM lParam)
+    public LRESULT WindowProc(HWND hWnd, MESSAGE_TYPE msg, WPARAM wParam, LPARAM lParam)
     {
         switch (msg)
         {


### PR DESCRIPTION
Fixes #57 (FancyMouse.WinUI3.exe crashes on notify icon) by caching the WndProc used by the tray icon so it doesn't get disposed and crashes when the tray icon tries to invoke it.