### PR TITLE
Feature/code review

### DIFF
--- a/src/FancyMouse.Common.UnitTests/Bezels/BezelProfileTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Bezels/BezelProfileTests.cs
@@ -1,0 +1,163 @@
+using FancyMouse.Common.Bezels;
+
+namespace FancyMouse.Common.UnitTests.Bezels;
+
+public static class BezelProfileTests
+{
+    [TestClass]
+    public sealed class BezelProfileCurvedTests
+    {
+        public sealed class NormalTestCase
+        {
+            public NormalTestCase(string testName, int n, int d, double position, double expectedNormal)
+            {
+                this.TestName = testName;
+                this.N = n;
+                this.D = d;
+                this.Position = position;
+                this.ExpectedNormal = expectedNormal;
+            }
+
+            public string TestName { get; }
+
+            public int N { get; }
+
+            public int D { get; }
+
+            public double Position { get; }
+
+            public double ExpectedNormal { get; }
+
+            public override string ToString() => this.TestName;
+        }
+
+        public static IEnumerable<object[]> GetNormalTestCases()
+        {
+            // n=20, d=5 - outer ring [0,5), flat zone [5,15), inner ring [15,20)
+            yield return new object[] { new NormalTestCase("outer arc edge - full highlight", 20, 5, 0.0, 0.0) };
+            yield return new object[] { new NormalTestCase("outer ring midpoint - arccos(0.5) sweep", 20, 5, 2.5, Math.PI / 3.0) };
+            yield return new object[] { new NormalTestCase("outer ring / flat zone boundary", 20, 5, 5.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("flat zone midpoint - no effect", 20, 5, 10.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("flat zone / inner ring boundary", 20, 5, 15.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("inner ring midpoint - arccos(0.5) sweep", 20, 5, 17.5, 2.0 * Math.PI / 3.0) };
+            yield return new object[] { new NormalTestCase("content boundary - full shadow", 20, 5, 20.0, Math.PI) };
+
+            // n=10, d=5 - depth is half the width (BezelRenderer.ClampDepth's own max), so the
+            // flat zone has zero width and outer/inner rings meet at a single continuous point
+            yield return new object[] { new NormalTestCase("zero-width flat zone - outer/inner ring boundary", 10, 5, 5.0, Math.PI / 2.0) };
+
+            // d=0 - no effect ring at all (e.g. a bezel with 3D depth disabled). There's no
+            // bevel surface to have a normal other than flat, even right at position 0 - a
+            // regression once caused a highlight rim to appear on zero-depth bezels because
+            // the "position <= 0 = facing the light" branch fired unconditionally. See
+            // BezelProfileCurved.GetProfileNormal's _d <= 0 guard.
+            yield return new object[] { new NormalTestCase("zero-depth ring - outer arc edge is flat, not highlighted", 20, 0, 0.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("zero-depth ring - interior is flat", 20, 0, 10.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("zero-depth ring - content boundary is flat, not shadowed", 20, 0, 20.0, Math.PI / 2.0) };
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(GetNormalTestCases))]
+        public void GetProfileNormal_ReturnsExpectedAngle(NormalTestCase data)
+        {
+            var profile = new BezelProfileCurved(data.N, data.D);
+            var proportion = data.Position / data.N;
+            var actual = profile.GetProfileNormal(proportion);
+            Assert.AreEqual(data.ExpectedNormal, actual, 1e-9);
+        }
+
+        [TestMethod]
+        [DataRow(-0.1)]
+        [DataRow(1.1)]
+        public void GetProfileNormal_ThrowsForProportionOutsideZeroToOne(double proportion)
+        {
+            var profile = new BezelProfileCurved(20, 5);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => profile.GetProfileNormal(proportion));
+        }
+
+        [TestMethod]
+        [DataRow(0.0)]
+        [DataRow(1.0)]
+        public void GetProfileNormal_AcceptsInclusiveBounds(double proportion)
+        {
+            var profile = new BezelProfileCurved(20, 5);
+            _ = profile.GetProfileNormal(proportion);
+        }
+    }
+
+    [TestClass]
+    public sealed class BezelProfileRampedTests
+    {
+        public sealed class NormalTestCase
+        {
+            public NormalTestCase(string testName, int n, int d, double rampAngleDegrees, double position, double expectedNormal)
+            {
+                this.TestName = testName;
+                this.N = n;
+                this.D = d;
+                this.RampAngleDegrees = rampAngleDegrees;
+                this.Position = position;
+                this.ExpectedNormal = expectedNormal;
+            }
+
+            public string TestName { get; }
+
+            public int N { get; }
+
+            public int D { get; }
+
+            public double RampAngleDegrees { get; }
+
+            public double Position { get; }
+
+            public double ExpectedNormal { get; }
+
+            public override string ToString() => this.TestName;
+        }
+
+        public static IEnumerable<object[]> GetNormalTestCases()
+        {
+            // n=20, d=5, rampAngle=30 deg (pi/6) - outer ring [0,5), flat zone [5,15), inner ring [15,20)
+            var rampAngle = Math.PI / 6.0;
+            yield return new object[] { new NormalTestCase("outer ring - constant ramp angle throughout", 20, 5, 30.0, 0.0, (Math.PI / 2.0) - rampAngle) };
+            yield return new object[] { new NormalTestCase("outer ring midpoint - same constant angle", 20, 5, 30.0, 2.5, (Math.PI / 2.0) - rampAngle) };
+            yield return new object[] { new NormalTestCase("flat zone start - no effect", 20, 5, 30.0, 5.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("flat zone midpoint - no effect", 20, 5, 30.0, 10.0, Math.PI / 2.0) };
+            yield return new object[] { new NormalTestCase("inner ring start - constant ramp angle throughout", 20, 5, 30.0, 15.0, (Math.PI / 2.0) + rampAngle) };
+            yield return new object[] { new NormalTestCase("inner ring midpoint - same constant angle", 20, 5, 30.0, 17.5, (Math.PI / 2.0) + rampAngle) };
+
+            // n=10, d=5 - depth is half the width, so the flat zone has zero width and the
+            // profile steps directly from the outer ring's constant angle to the inner ring's
+            // (unlike BezelProfileCurved, there's no continuous handoff at this boundary)
+            yield return new object[] { new NormalTestCase("zero-width flat zone - steps straight to inner ring", 10, 5, 30.0, 5.0, (Math.PI / 2.0) + rampAngle) };
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(GetNormalTestCases))]
+        public void GetProfileNormal_ReturnsExpectedAngle(NormalTestCase data)
+        {
+            var profile = new BezelProfileRamped(data.N, data.D, data.RampAngleDegrees);
+            var proportion = data.Position / data.N;
+            var actual = profile.GetProfileNormal(proportion);
+            Assert.AreEqual(data.ExpectedNormal, actual, 1e-9);
+        }
+
+        [TestMethod]
+        [DataRow(-0.1)]
+        [DataRow(1.1)]
+        public void GetProfileNormal_ThrowsForProportionOutsideZeroToOne(double proportion)
+        {
+            var profile = new BezelProfileRamped(20, 5, 30.0);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => profile.GetProfileNormal(proportion));
+        }
+
+        [TestMethod]
+        [DataRow(0.0)]
+        [DataRow(1.0)]
+        public void GetProfileNormal_AcceptsInclusiveBounds(double proportion)
+        {
+            var profile = new BezelProfileRamped(20, 5, 30.0);
+            _ = profile.GetProfileNormal(proportion);
+        }
+    }
+}

--- a/src/FancyMouse.Common.UnitTests/Bezels/BezelRendererTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Bezels/BezelRendererTests.cs
@@ -1,0 +1,199 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+
+using FancyMouse.Common.Bezels;
+using FancyMouse.Models.Styles;
+
+namespace FancyMouse.Common.UnitTests.Bezels;
+
+public static class BezelRendererTests
+{
+    [TestClass]
+    public sealed class ClampDepthTests
+    {
+        public sealed class TestCase
+        {
+            public TestCase(string testName, BorderStyle borderStyle, BorderStyle expectedResult)
+            {
+                this.TestName = testName;
+                this.BorderStyle = borderStyle;
+                this.ExpectedResult = expectedResult;
+            }
+
+            public string TestName { get; }
+
+            public BorderStyle BorderStyle { get; }
+
+            public BorderStyle ExpectedResult { get; }
+
+            public override string ToString() => this.TestName;
+        }
+
+        public static IEnumerable<object[]> GetTestCases()
+        {
+            // depth well within half the thickness - unchanged
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "depth < thickness / 2 is unchanged",
+                    borderStyle: new(Color.Red, all: 10, depth: 3),
+                    expectedResult: new(Color.Red, all: 10, depth: 3)),
+            };
+
+            // depth exactly half the thickness - unchanged (still leaves a zero-width, not
+            // negative-width, flat band in the middle)
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "depth == thickness / 2 is unchanged",
+                    borderStyle: new(Color.Red, all: 10, depth: 5),
+                    expectedResult: new(Color.Red, all: 10, depth: 5)),
+            };
+
+            // the example from the bug report: thickness 10, depth 8 renders as thickness 10,
+            // depth 5 - the *stored* value (asserted separately in RunTestCases) stays 8
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "depth > thickness / 2 clamps to thickness / 2",
+                    borderStyle: new(Color.Red, all: 10, depth: 8),
+                    expectedResult: new(Color.Red, all: 10, depth: 5)),
+            };
+
+            // the actual reported repro values - thickness 25, depth 23
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "reported repro - thickness 25, depth 23 clamps to 12.5",
+                    borderStyle: new(Color.Red, all: 25, depth: 23),
+                    expectedResult: new(Color.Red, all: 25, depth: 12.5m)),
+            };
+
+            // asymmetric thickness - clamp is driven by the *thinnest* side, so corners on that
+            // side can't overlap either
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "asymmetric thickness clamps to the thinnest side / 2",
+                    borderStyle: new(Color.Red, left: 10, top: 20, right: 10, bottom: 20, depth: 8),
+                    expectedResult: new(Color.Red, left: 10, top: 20, right: 10, bottom: 20, depth: 5)),
+            };
+
+            // zero thickness - any positive depth clamps down to zero
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "zero thickness clamps depth to zero",
+                    borderStyle: new(Color.Red, all: 0, depth: 4),
+                    expectedResult: new(Color.Red, all: 0, depth: 0)),
+            };
+
+            // depth already zero - unchanged
+            yield return new object[]
+            {
+                new TestCase(
+                    testName: "zero depth is unchanged",
+                    borderStyle: new(Color.Red, all: 10, depth: 0),
+                    expectedResult: new(Color.Red, all: 10, depth: 0)),
+            };
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(GetTestCases))]
+        public void RunTestCases(TestCase data)
+        {
+            var actual = BezelRenderer.ClampDepth(data.BorderStyle);
+            var expected = data.ExpectedResult;
+
+            Assert.AreEqual(expected.Color, actual.Color);
+            Assert.AreEqual(expected.Left, actual.Left);
+            Assert.AreEqual(expected.Top, actual.Top);
+            Assert.AreEqual(expected.Right, actual.Right);
+            Assert.AreEqual(expected.Bottom, actual.Bottom);
+            Assert.AreEqual(expected.Depth, actual.Depth);
+
+            // ClampDepth must never mutate the caller's own BorderStyle (it can't - BorderStyle
+            // has no setters - but it must also not just hand the same instance back once it's
+            // decided to clamp) - config/settings should keep whatever Depth the user actually
+            // entered, even when rendering clamps it.
+            if (data.BorderStyle.Depth != expected.Depth)
+            {
+                Assert.AreNotSame(data.BorderStyle, actual);
+            }
+        }
+    }
+
+    [TestClass]
+    public sealed class DrawBezelTests
+    {
+        // thickness=12, depth=4 -> outer highlight ring [0,4), flat zone [4,8),
+        // inner shadow ring [8,12) on each edge
+        private const int Thickness = 12;
+        private const int Depth = 4;
+        private const int ImageSize = 60;
+
+        [TestMethod]
+        public void DrawBezel_LeavesInteriorUntouched()
+        {
+            using var bitmap = DrawBezelTests.RenderBezel(out _);
+
+            // the content area inside the ring is never drawn to - DrawBezel draws a frame,
+            // not a filled rectangle - so it must still be the fully-transparent pixel the
+            // bitmap started with
+            var interior = bitmap.GetPixel(ImageSize / 2, ImageSize / 2);
+            Assert.AreEqual(Color.FromArgb(0, 0, 0, 0), interior);
+        }
+
+        [TestMethod]
+        public void DrawBezel_FlatZoneIsUnlitBorderColor()
+        {
+            using var bitmap = DrawBezelTests.RenderBezel(out var borderColor);
+
+            // position 6 sits inside [depth, thickness-depth) = [4, 8), the flat zone with no
+            // lighting effect - well clear of both corners (x is mid-edge), so this pixel
+            // should be exactly the plain, unlit border colour
+            var flatZonePixel = bitmap.GetPixel(ImageSize / 2, 6);
+            Assert.AreEqual(borderColor, flatZonePixel);
+        }
+
+        [TestMethod]
+        public void DrawBezel_OuterTopEdgeIsHighlighted()
+        {
+            using var bitmap = DrawBezelTests.RenderBezel(out var borderColor);
+
+            // the outermost row of the top edge, clear of both corners - light source is
+            // top-left (see DrawBezel's own doc), so this should be lightened, not darkened
+            var highlightPixel = bitmap.GetPixel(20, 0);
+            Assert.IsTrue(
+                highlightPixel.R > borderColor.R && highlightPixel.G > borderColor.G && highlightPixel.B > borderColor.B,
+                $"expected a pixel lighter than {borderColor}, got {highlightPixel}");
+        }
+
+        [TestMethod]
+        public void DrawBezel_OuterBottomEdgeNearCornerIsShadowed()
+        {
+            using var bitmap = DrawBezelTests.RenderBezel(out var borderColor);
+
+            // the outermost row of the bottom edge, close to the bottom-right corner (the
+            // strong/corner-adjacent end of that edge's gradient) - facing away from the
+            // top-left light source, so this should be darkened, not lightened
+            var shadowPixel = bitmap.GetPixel(40, ImageSize - 1);
+            Assert.IsTrue(
+                shadowPixel.R < borderColor.R && shadowPixel.G < borderColor.G && shadowPixel.B < borderColor.B,
+                $"expected a pixel darker than {borderColor}, got {shadowPixel}");
+        }
+
+        private static Bitmap RenderBezel(out Color borderColor)
+        {
+            borderColor = Color.FromArgb(255, 100, 100, 100); // mid-grey - room to lighten or darken either way
+            var borderStyle = new BorderStyle(borderColor, all: Thickness, depth: Depth);
+            using var renderer = new BezelRenderer(borderStyle);
+
+            var bitmap = new Bitmap(ImageSize, ImageSize, PixelFormat.Format32bppArgb);
+            using var g = Graphics.FromImage(bitmap);
+            g.Clear(Color.Transparent);
+            renderer.DrawBezel(g, 0, 0, ImageSize, ImageSize);
+            return bitmap;
+        }
+    }
+}

--- a/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
@@ -200,14 +200,18 @@ public static class DrawingHelperTests
             var offsetX = (int)hostBounds.ContentBounds.X;
             var offsetY = (int)hostBounds.ContentBounds.Y;
 
-            using var borderImage = DrawingHelper.RenderBorder(hostBounds, hostBoxStyle);
-            using var backgroundImage = DrawingHelper.RenderBackground(canvasLayout);
+            // RenderBorder/RenderBackground are no longer box-aware - they just draw as large as
+            // the size they're given, so it's on this caller to position the result at the right
+            // box-model rectangle (BorderBounds/PaddingBounds/etc.) itself.
+            var hostBorderBounds = hostBounds.BorderBounds;
+            using var borderImage = DrawingHelper.RenderBorder(hostBorderBounds.Size, hostBoxStyle.BorderStyle);
+            using var backgroundImage = DrawingHelper.RenderBackground(canvasLayout.CanvasBounds.OuterBounds.Size, canvasLayout.CanvasStyle.BackgroundStyle);
 
             var combinedBounds = hostBounds.OuterBounds.ToRectangle();
             var combinedImage = new Bitmap(combinedBounds.Width, combinedBounds.Height, PixelFormat.Format32bppPArgb);
             using var combinedGraphics = Graphics.FromImage(combinedImage);
             combinedGraphics.Clear(Color.Transparent);
-            combinedGraphics.DrawImageUnscaled(borderImage, 0, 0);
+            combinedGraphics.DrawImageUnscaled(borderImage, (int)hostBorderBounds.X, (int)hostBorderBounds.Y);
             combinedGraphics.DrawImageUnscaled(backgroundImage, offsetX, offsetY);
 
             var captureProvider = new StaticScreenshotCaptureProvider(desktopImage);
@@ -217,18 +221,13 @@ public static class DrawingHelperTests
                 {
                     // screens sit at a fractional (scaled) position within the canvas, unlike
                     // the canvas/host boxes above which are already zero-based - anchor at the
-                    // *truncated* outer position and re-anchor the screen's own bounds to the
-                    // leftover fractional remainder (not exactly zero), so the single pixel
-                    // truncation this produces lines up with the one truncation DrawRaisedBorder
-                    // would have applied had it drawn straight onto the combined image at this
-                    // screen's absolute (fractional) bounds, the way production code once did.
-                    var screenOuterBounds = screenLayout.ScreenBounds.OuterBounds;
-                    var anchorX = (int)screenOuterBounds.X;
-                    var anchorY = (int)screenOuterBounds.Y;
-                    var localScreenBounds = screenLayout.ScreenBounds.MoveTo(
-                        new PointInfo(screenOuterBounds.X - anchorX, screenOuterBounds.Y - anchorY));
+                    // *truncated* border position, matching how production now positions the
+                    // bezel bitmap (see PreviewPane.CreateScreenSlot/PositionElement).
+                    var screenBorderBounds = screenLayout.ScreenBounds.BorderBounds;
+                    var anchorX = (int)screenBorderBounds.X;
+                    var anchorY = (int)screenBorderBounds.Y;
 
-                    using var bezelImage = DrawingHelper.RenderBorder(localScreenBounds, screenLayout.ScreenStyle);
+                    using var bezelImage = DrawingHelper.RenderBorder(screenBorderBounds.Size, screenLayout.ScreenStyle.BorderStyle);
                     combinedGraphics.DrawImageUnscaled(
                         bezelImage,
                         offsetX + anchorX,

--- a/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Helpers/DrawingHelperTests.cs
@@ -147,7 +147,7 @@ public static class DrawingHelperTests
             var previewLayout = LayoutHelper.GetPreviewLayout(
                 previewStyle: data.PreviewStyle,
                 displayInfo: data.DisplayInfo,
-                activatedScreen: data.ActivatedScreen);
+                maximumSize: data.ActivatedScreen.DisplayArea.Size);
 
             // draw the preview image - the combined (border+background+bezels/screenshots)
             // render, since the expected golden images were captured against that. Production
@@ -156,8 +156,8 @@ public static class DrawingHelperTests
             // test composes them the same way for comparison purposes only, using the same
             // production rendering primitives (DrawingHelper.RenderBorder/RenderBackground,
             // and StaticScreenshotCaptureProvider for the screenshot content).
-            var hostBoxStyle = LayoutHelper.GetHostBoxStyle(data.PreviewStyle.CanvasStyle);
-            using var actual = await GetPreviewLayoutTests.ComposePreviewImageAsync(previewLayout, hostBoxStyle, desktopImage);
+            var previewWindowStyle = LayoutHelper.GetPreviewWindowStyle(data.PreviewStyle.CanvasStyle);
+            using var actual = await GetPreviewLayoutTests.ComposePreviewImageAsync(previewLayout, previewWindowStyle, desktopImage);
 
             var currentDirectory = Environment.CurrentDirectory;
 
@@ -191,7 +191,7 @@ public static class DrawingHelperTests
             PreviewLayout previewLayout, BoxStyle hostBoxStyle, Bitmap desktopImage)
         {
             var canvasLayout = previewLayout.CanvasLayout;
-            var hostBounds = LayoutHelper.GetHostBounds(canvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
+            var hostBounds = LayoutHelper.GetPreviewWindowBounds(canvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
                 .MoveTo(new PointInfo(0, 0));
 
             // hostBounds.OuterBounds is now (0,0)-based, so hostBounds.ContentBounds.Location
@@ -293,22 +293,12 @@ public static class DrawingHelperTests
                     var expectedPixel = expected.GetPixel(x, y);
                     var actualPixel = actual.GetPixel(x, y);
 
-                    // allow a small tolerance for rounding differences in gdi - capturing each
-                    // screen's content into its own independent bitmap (see
-                    // StaticScreenshotCaptureProvider) rather than drawing it directly at its
-                    // final absolute position on one shared canvas (the old, pre-capture-pipeline
-                    // behavior) can shift GDI+'s interpolation sampling by a fraction of a
-                    // source pixel at a scaled screenshot's edges, since the same NearestNeighbor
-                    // scaling now runs against a local (0,0)-based destination rect instead of
-                    // one positioned at the final canvas offset. This only ever affects a
-                    // handful of edge pixels by a couple of levels at most - a tolerance of 1
-                    // was too tight for that, verified by counting affected pixels directly
-                    // rather than just loosening the check blindly.
+                    // allow a 1-level-per-channel tolerance for residual GDI+ rasterization rounding.
                     Assert.IsTrue(
-                        (Math.Abs(expectedPixel.A - actualPixel.A) <= 3) &&
-                        (Math.Abs(expectedPixel.R - actualPixel.R) <= 3) &&
-                        (Math.Abs(expectedPixel.G - actualPixel.G) <= 3) &&
-                        (Math.Abs(expectedPixel.B - actualPixel.B) <= 3),
+                        (Math.Abs(expectedPixel.A - actualPixel.A) <= 1) &&
+                        (Math.Abs(expectedPixel.R - actualPixel.R) <= 1) &&
+                        (Math.Abs(expectedPixel.G - actualPixel.G) <= 1) &&
+                        (Math.Abs(expectedPixel.B - actualPixel.B) <= 1),
                         $"images differ at pixel ({x}, {y}) - expected: {expectedPixel}, actual: {actualPixel}");
                 }
             }

--- a/src/FancyMouse.Common.UnitTests/Helpers/LayoutHelperTests.cs
+++ b/src/FancyMouse.Common.UnitTests/Helpers/LayoutHelperTests.cs
@@ -132,7 +132,7 @@ public static class LayoutHelperTests
             /// <summary>
             /// Gets the window bounds a host would end up with after wrapping <see cref="ExpectedResult"/>'s
             /// <see cref="PreviewLayout.PreviewSize"/> in its own host box (see
-            /// <see cref="LayoutHelper.GetHostBoxStyle"/>) and positioning it via
+            /// <see cref="LayoutHelper.GetPreviewWindowStyle"/>) and positioning it via
             /// <see cref="LayoutHelper.PositionOnScreen"/> - preserved from before PreviewLayout's
             /// own position was removed, so this coverage doesn't get lost.
             /// </summary>
@@ -199,8 +199,8 @@ public static class LayoutHelperTests
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 514, 386),
-                        boxStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle)),
-                    canvasStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle),
+                        boxStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle)),
+                    canvasStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle),
                     deviceLayouts: new List<DeviceLayout>()
                     {
                         new(
@@ -277,8 +277,8 @@ public static class LayoutHelperTests
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 512, 384),
-                        boxStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle)),
-                    canvasStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle),
+                        boxStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle)),
+                    canvasStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle),
                     deviceLayouts: new List<DeviceLayout>()
                     {
                         new(
@@ -348,8 +348,8 @@ public static class LayoutHelperTests
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 300, 67),
-                        boxStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle)),
-                    canvasStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle),
+                        boxStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle)),
+                    canvasStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle),
                     deviceLayouts: new List<DeviceLayout>()
                     {
                         new(
@@ -448,8 +448,8 @@ public static class LayoutHelperTests
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 706, 194),
-                        boxStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle)),
-                    canvasStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle),
+                        boxStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle)),
+                    canvasStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle),
                     deviceLayouts: new List<DeviceLayout>()
                     {
                         new(
@@ -530,8 +530,8 @@ public static class LayoutHelperTests
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 1600, 225),
-                        boxStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle)),
-                    canvasStyle: LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle),
+                        boxStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle)),
+                    canvasStyle: LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle),
                     deviceLayouts: new List<DeviceLayout>()
                     {
                         new(
@@ -585,7 +585,7 @@ public static class LayoutHelperTests
             // (int)1280.000000000000 -> 1280
             // so we'll compare the raw values, *and* convert to an int-based
             // Rectangle to compare rounded values
-            var actual = LayoutHelper.GetPreviewLayout(data.PreviewStyle, data.DisplayInfo, data.ActivatedScreen);
+            var actual = LayoutHelper.GetPreviewLayout(data.PreviewStyle, data.DisplayInfo, data.ActivatedScreen.DisplayArea.Size);
             var expected = data.ExpectedResult;
             var options = new JsonSerializerOptions
             {
@@ -599,8 +599,8 @@ public static class LayoutHelperTests
             // wrapping it in its own box and positioning the result still ends up in the same
             // place a pre-split FormBounds/PreviewBounds would have (this is coverage that
             // used to live inside GetPreviewLayout itself, before the position/size split).
-            var hostBoxStyle = LayoutHelper.GetHostBoxStyle(data.PreviewStyle.CanvasStyle);
-            var hostBounds = LayoutHelper.GetHostBounds(new RectangleInfo(actual.PreviewSize), hostBoxStyle);
+            var previewWindowStyle = LayoutHelper.GetPreviewWindowStyle(data.PreviewStyle.CanvasStyle);
+            var hostBounds = LayoutHelper.GetPreviewWindowBounds(new RectangleInfo(actual.PreviewSize), previewWindowStyle);
             var actualWindowBounds = LayoutHelper.PositionOnScreen(hostBounds.OuterBounds, data.ActivatedScreen, data.ActivatedLocation);
             var expectedWindowBounds = data.ExpectedWindowBounds;
             Assert.AreEqual(expectedWindowBounds.X, actualWindowBounds.X);
@@ -685,7 +685,7 @@ public static class LayoutHelperTests
             var timer = Stopwatch.StartNew();
             for (var i = 0; i < 10_000; i++)
             {
-                var previewLayout = LayoutHelper.GetPreviewLayout(previewStyle, displayInfo, activatedScreen);
+                var previewLayout = LayoutHelper.GetPreviewLayout(previewStyle, displayInfo, activatedScreen.DisplayArea.Size);
             }
 
             timer.Stop();

--- a/src/FancyMouse.Common/Helpers/BlurHelper.cs
+++ b/src/FancyMouse.Common/Helpers/BlurHelper.cs
@@ -7,22 +7,27 @@ namespace FancyMouse.Common.Helpers;
 /// Helpers to apply a blur to an image and return the result as a new image.
 /// </summary>
 /// <remarks>
-/// Blur is used to soften a screen's last real screenshot for use as a stand-in placeholder while a
-/// fresh one is still loading. Runs a three-pass separable box blur (each pass a horizontal then
-/// a vertical sliding-window average) directly on the bitmap's own pixels - three passes closely
-/// approximates a true Gaussian blur, without the cost of a real Gaussian convolution kernel, and
-/// each pass is O(pixel count) regardless of blur radius. This is deliberately not the cheapest
-/// possible approximation: unlike the capture pipeline itself, generating this stand-in isn't on
-/// any latency-critical path (it happens once a real screenshot has already arrived, well after
-/// the window is showing - see <see cref="Capture.ScreenshotCapturePipeline"/>), so there's no
-/// reason to trade visual quality for speed here the way there is elsewhere.
+/// If a screenshot capture takes too long during an activation the preview
+/// window gets displayed using a blurred version of the previous screenshot
+/// for that screen. When the new capture is complete the blurred image is
+/// replaced with the actual screenshot - this creates the impression that
+/// the preview window actually loads faster than it does.
+///
+/// The blur algorithm runs a three-pass separable box blur (each pass a
+/// horizontal then a vertical sliding-window average) directly on the bitmap's
+/// pixels - three passes closely approximates a true Gaussian blur, without
+/// the cost of a real Gaussian convolution kernel, and each pass is O(pixel count)
+/// regardless of blur radius. This is not specifically the *cheapest* possible
+/// approximation: unlike the capture pipeline, blurred images are generated
+/// in the background once the previous activation has been closed so the
+/// blur process is not as performance-sensitive as the capture process.
 /// </remarks>
 public static class BlurHelper
 {
     /// <summary>
     /// Blur radius, in pixels, at the blurriest end of <see cref="CreateBlurredCopy"/>'s
-    /// <c>intensity</c> range (<c>intensity</c> approaching 0). The radius scales down to 1px as
-    /// <c>intensity</c> approaches 1.
+    /// <c>blurIntensity</c> range (<c>blurIntensity</c> approaching 0). The radius scales down to 1px as
+    /// <c>blurIntensity</c> approaches 1.
     /// </summary>
     private const int MaxBlurRadius = 40;
 
@@ -39,20 +44,15 @@ public static class BlurHelper
 
     /// <summary>
     /// Returns a new bitmap, the same size as <paramref name="source"/>, desaturated and
-    /// darkened, then blurred. <paramref name="intensity"/> is the knob to experiment with for
-    /// blurriness - closer to 1.0 is barely blurred, closer to 0.0 is heavily blurred.
-    /// <paramref name="saturation"/> and <paramref name="brightness"/> are knobs from 0 (fully
-    /// grey / black) to 1 (unchanged) - muting the stand-in this way, on top of the blur itself,
-    /// is what makes the real screenshot visually "pop" into place once it actually arrives,
-    /// rather than the swap reading as a same-ish image just sharpening.
+    /// darkened, then blurred.
     /// </summary>
-    public static Bitmap CreateBlurredCopy(Bitmap source, decimal intensity, double saturation = 1.0, double brightness = 1.0)
+    public static Bitmap CreateBlurredCopy(Bitmap source, decimal blurIntensity, double saturation = 1.0, double brightness = 1.0)
     {
         ArgumentNullException.ThrowIfNull(source);
-        if (intensity is <= 0 or > 1)
+        if (blurIntensity is <= 0 or > 1)
         {
             throw new ArgumentOutOfRangeException(
-                nameof(intensity), intensity, "Value must be greater than 0 and less than or equal to 1.");
+                nameof(blurIntensity), blurIntensity, "Value must be greater than 0 and less than or equal to 1.");
         }
 
         var mutedImage = new Bitmap(source.Width, source.Height, PixelFormat.Format32bppPArgb);
@@ -69,7 +69,7 @@ public static class BlurHelper
             GraphicsUnit.Pixel,
             imageAttributes);
 
-        var radius = Math.Max(1, (int)((1 - intensity) * BlurHelper.MaxBlurRadius));
+        var radius = Math.Max(1, (int)((1 - blurIntensity) * BlurHelper.MaxBlurRadius));
         BlurHelper.ApplyBoxBlur(mutedImage, radius);
 
         return mutedImage;

--- a/src/FancyMouse.Common/Helpers/ColorHelper.cs
+++ b/src/FancyMouse.Common/Helpers/ColorHelper.cs
@@ -75,10 +75,10 @@ public static class ColorHelper
         }
 
         // e.g. "SystemColors.Highlight"
-        const string systemColorPrefix = $"{nameof(SystemColors)}.";
-        if (value.StartsWith(systemColorPrefix, comparison))
+        const string systemColorsPrefix = $"{nameof(SystemColors)}.";
+        if (value.StartsWith(systemColorsPrefix, comparison))
         {
-            var colorName = value[systemColorPrefix.Length..];
+            var colorName = value[systemColorsPrefix.Length..];
             var property = typeof(SystemColors).GetProperties()
                 .SingleOrDefault(property => property.Name == colorName);
             if (property is not null)

--- a/src/FancyMouse.Common/Helpers/DrawingHelper.cs
+++ b/src/FancyMouse.Common/Helpers/DrawingHelper.cs
@@ -4,7 +4,6 @@ using System.Drawing.Imaging;
 
 using FancyMouse.Common.Bezels;
 using FancyMouse.Models.Drawing;
-using FancyMouse.Models.Layout;
 using FancyMouse.Models.Styles;
 
 namespace FancyMouse.Common.Helpers;
@@ -12,121 +11,74 @@ namespace FancyMouse.Common.Helpers;
 public static class DrawingHelper
 {
     /// <summary>
-    /// Renders the gradient-filled background for the specified canvas layout, as its own
-    /// transparent-elsewhere image sized to <paramref name="canvasLayout"/>'s own outer
-    /// bounds - a hosting window layers this beneath the per-screen bezels/screenshots (and,
-    /// separately, its own border image) rather than having it baked into a single flattened
-    /// bitmap.
+    /// Renders the gradient-filled background for a box of the given <paramref name="size"/>.
+    /// Can be used to render the main background for the preview pane, and the screen
+    /// background image for delayed screenshot capture scenarios.
     /// </summary>
-    public static Bitmap RenderBackground(CanvasLayout canvasLayout)
+    public static Bitmap RenderBackground(SizeInfo size, BackgroundStyle backgroundStyle)
     {
-        var bounds = canvasLayout.CanvasBounds.OuterBounds.ToRectangle();
-        var image = new Bitmap(bounds.Width, bounds.Height, PixelFormat.Format32bppPArgb);
+        // prepare the bitmap (with a transparent background) to draw the background fill onto
+        var backgroundBounds = new RectangleInfo(size).ToRectangle();
+        var image = new Bitmap(backgroundBounds.Width, backgroundBounds.Height, PixelFormat.Format32bppPArgb);
         using var graphics = Graphics.FromImage(image);
         graphics.Clear(Color.Transparent);
-        DrawingHelper.DrawBackgroundFill(
-            graphics,
-            canvasLayout.CanvasStyle,
-            canvasLayout.CanvasBounds,
-            []);
-        return image;
-    }
 
-    /// <summary>
-    /// Renders a raised border ring for the specified box, as its own transparent-elsewhere
-    /// image sized to <paramref name="hostBounds"/>'s outer bounds. Used both by a hosting
-    /// window to render its own outer border (see
-    /// <see cref="LayoutHelper.GetHostBoxStyle"/>/<see cref="LayoutHelper.GetHostBounds"/>)
-    /// and, per screen, to render each screen's bezel - the two uses share this method because
-    /// a bezel is just a border ring around a smaller box.
-    /// </summary>
-    /// <remarks>
-    /// <paramref name="hostBounds"/> must be zero-based (<c>OuterBounds.Location == (0,0)</c>)
-    /// - its rectangles are used directly as pixel coordinates into the bitmap this
-    /// allocates, which is sized to exactly fit it. Callers deriving a box by enlarging or
-    /// using a non-zero-based content box (e.g. <see cref="LayoutHelper.GetHostBounds"/>, or a
-    /// <see cref="ScreenLayout.ScreenBounds"/> which is relative to the canvas origin,
-    /// not its own) need to re-anchor it first - e.g. <c>bounds.MoveTo(new PointInfo(0, 0))</c>.
-    /// </remarks>
-    public static Bitmap RenderBorder(BoxBounds hostBounds, BoxStyle hostStyle)
-    {
-        var bounds = hostBounds.OuterBounds.ToRectangle();
-        var image = new Bitmap(bounds.Width, bounds.Height, PixelFormat.Format32bppPArgb);
-        using var graphics = Graphics.FromImage(image);
-        graphics.Clear(Color.Transparent);
-        DrawingHelper.DrawRaisedBorder(graphics, hostBounds, hostStyle);
-        return image;
-    }
-
-    /// <summary>
-    /// Draws a border shape with a raised 3-D highlight and shadow effect.
-    /// </summary>
-    private static void DrawRaisedBorder(
-        Graphics graphics, BoxBounds boxBounds, BoxStyle boxStyle)
-    {
-        var borderStyle = boxStyle.BorderStyle;
-        if ((borderStyle.Horizontal < 1) || (borderStyle.Vertical < 1))
-        {
-            return;
-        }
-
-        if (borderStyle.Color is null)
-        {
-            return;
-        }
-
-        // draw a contoured bezel
-        var bounds = boxBounds.BorderBounds.ToRectangle();
-        using var renderer = new BezelRenderer(borderStyle);
-        renderer.DrawBezel(graphics, bounds.X, bounds.Y, bounds.Width, bounds.Height);
-    }
-
-    /// <summary>
-    /// Draws a gradient-filled background shape.
-    /// </summary>
-    private static void DrawBackgroundFill(
-        Graphics graphics, BoxStyle boxStyle, BoxBounds boxBounds, IEnumerable<RectangleInfo> excludeBounds)
-    {
-        var backgroundBounds = boxBounds.PaddingBounds;
-
-        using var backgroundBrush = DrawingHelper.GetBackgroundStyleBrush(boxStyle.BackgroundStyle, backgroundBounds);
-        if (backgroundBrush == null)
-        {
-            return;
-        }
-
-        // it's faster to build a region with the screen areas excluded
-        // and fill that than it is to fill the entire bounding rectangle
-        var backgroundRegion = new Region(backgroundBounds.ToRectangle());
-        foreach (var exclude in excludeBounds)
-        {
-            backgroundRegion.Exclude(exclude.ToRectangle());
-        }
-
-        graphics.FillRegion(backgroundBrush, backgroundRegion);
-    }
-
-    private static Brush? GetBackgroundStyleBrush(BackgroundStyle backgroundStyle, RectangleInfo backgroundBounds)
-    {
-        var backgroundBrush = backgroundStyle switch
+        // pick a brush matching the configured background - a two-colour gradient, a solid fill
+        // (whichever single colour is set), or nothing at all if neither colour is configured
+        using var backgroundBrush = backgroundStyle switch
         {
             { Color1: not null, Color2: not null } =>
                 /* draw a gradient fill if both colors are specified */
                 new LinearGradientBrush(
-                    backgroundBounds.ToRectangle(),
+                    backgroundBounds,
                     backgroundStyle.Color1.Value,
                     backgroundStyle.Color2.Value,
                     LinearGradientMode.ForwardDiagonal),
             { Color1: not null } =>
                 /* draw a solid fill if only one color is specified */
-                new SolidBrush(
-                    backgroundStyle.Color1.Value),
+                new SolidBrush(backgroundStyle.Color1.Value),
             { Color2: not null } =>
                 /* draw a solid fill if only one color is specified */
-                new SolidBrush(
-                    backgroundStyle.Color2.Value),
+                new SolidBrush(backgroundStyle.Color2.Value),
             _ => (Brush?)null,
         };
-        return backgroundBrush;
+
+        // fill the background, if a colour was actually configured
+        if (backgroundBrush is not null)
+        {
+            graphics.FillRectangle(backgroundBrush, backgroundBounds);
+        }
+
+        return image;
+    }
+
+    /// <summary>
+    /// Renders a raised border ring for a box of the given <paramref name="size"/>.
+    /// Can be used to render the main preview window border, and the individual
+    /// screen bezels.
+    /// </summary>
+    public static Bitmap RenderBorder(SizeInfo size, BorderStyle borderStyle)
+    {
+        // prepare the bitmap (with a transparent background) to draw the border / bezel onto
+        var borderBounds = new RectangleInfo(size).ToRectangle();
+        var image = new Bitmap(borderBounds.Width, borderBounds.Height, PixelFormat.Format32bppPArgb);
+        using var graphics = Graphics.FromImage(image);
+        graphics.Clear(Color.Transparent);
+
+        if ((borderStyle.Horizontal < 1) || (borderStyle.Vertical < 1))
+        {
+            return image;
+        }
+
+        if (borderStyle.Color is null)
+        {
+            return image;
+        }
+
+        // draw a contoured border (could be an outer border or a bezel)
+        using var renderer = new BezelRenderer(borderStyle);
+        renderer.DrawBezel(graphics, borderBounds.X, borderBounds.Y, borderBounds.Width, borderBounds.Height);
+
+        return image;
     }
 }

--- a/src/FancyMouse.Common/Helpers/LayoutHelper.cs
+++ b/src/FancyMouse.Common/Helpers/LayoutHelper.cs
@@ -10,67 +10,112 @@ namespace FancyMouse.Common.Helpers;
 
 public static class LayoutHelper
 {
+    /*
+
+        we use a poor-man's version of the w3c "box model" (see FancyMouse.Models.Styles.BoxStyle)
+        to calculate sizes and positions of individual ui components. the diagram below shows the
+        logical organisation of components:
+
+        * the overall PreviewWindow - a container for all of the ui components. this directly
+          hosts the outer preview border control, a child PreviewPane and a status bar control
+
+          +--------[preview window]--------+
+          |▒▒▒▒▒▒▒▒▒[outer border]▒▒▒▒▒▒▒▒▒|
+          |▒▒+------[preview pane]------+▒▒|
+          |▒▒|                          |▒▒|
+          |▒▒|                          |▒▒|
+          |▒▒|                          |▒▒|
+          |▒▒+--------------------------+▒▒|
+          |▒▒+-------[status bar]-------+▒▒|
+          |▒▒|░░░░░░░░░░░░░░░░░░░░░░░░░░|▒▒|
+          |▒▒+--------------------------+▒▒|
+          |▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒|
+          +--------------------------------+
+
+        * the child PreviewPane - this contains the preview background, the padding from the
+          outer border, the screen bezels and screenshot images. the "device grid" in the diagram
+          is a logical grid - it doesn't exist in the layout or control hierarchy, and only
+          exists as a set of temporary bounds during the actual layout calculation.
+
+          +---------------------------[preview pane]----------------------------+
+          |+---------------------------[background]----------------------------+|
+          ||░░░░░░░░░░░░░░░░░░░░░░░░░░░░░[padding]░░░░░░░░░░░░░░░░░░░░░░░░░░░░░||
+          ||▒▒+------------------------[device grid]-+----------------------+▒▒||
+          ||▒▒|                                      |▓▓▓▓▓▓[device 2]▓▓▓▓▓▓|▒▒||
+          ||▒▒|                                      |▓▓░░░░[screen 1]░░░░▓▓|▒▒||
+          ||▒▒|▓▓▓▓▓▓▓▓▓▓▓▓▓▓[device 1]▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|▓▓░░░░[screen 1]░░░░░░[screen 2]░░░░▓▓|▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░░░░░░░░░░░░░░░░░▓▓|▒▒||
+          ||▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░░░[screen 2]░░░░▓▓|▒▒||
+          ||▒▒|▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▓▓|▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|                                      |▓▓░░              ░░▓▓|▒▒||
+          ||▒▒|                                      |▓▓░░░░░░░░░░░░░░░░░░▓▓|▒▒||
+          ||▒▒|                                      |▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▒▒||
+          ||▒▒+--------------------------------------+----------------------+▒▒||
+          ||▒▒|        ▓▓▓▓▓▓[device 3]▓▓▓▓▓▓        |                      |▒▒||
+          ||▒▒|        ▓▓░░░░[screen 1]░░░░▓▓        |                      |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |                      |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |   ▓▓▓[device 4]▓▓▓   |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |   ▓▓░[screen 1]░▓▓   |▒▒||
+          ||▒▒|        ▓▓░░░░░░░░░░░░░░░░░░▓▓        |   ▓▓░░        ░░▓▓   |▒▒||
+          ||▒▒|        ▓▓░░░░[screen 2]░░░░▓▓        |   ▓▓░░        ░░▓▓   |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |   ▓▓░░░░░░░░░░░░▓▓   |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |   ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓   |▒▒||
+          ||▒▒|        ▓▓░░              ░░▓▓        |                      |▒▒||
+          ||▒▒|        ▓▓░░░░░░░░░░░░░░░░░░▓▓        |                      |▒▒||
+          ||▒▒|        ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓        |                      |▒▒||
+          ||▒▒+-------------------------------------------------------------+▒▒||
+          ||▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒||
+          |+-------------------------------------------------------------------+|
+          +---------------------------------------------------------------------+
+
+        note that the style settings in the config file get chopped up into two
+        different layouts - the outer border's *margin* and *thickness* belong
+        in the PreviewWindow but the outer *padding* is converted into an inner
+        padding inside the PreviewPane so the background can belong inside the
+        PreviewPane and be the correct size, rather than owned by the outer
+        PreviewWindow.
+
+    */
+
+    /// <summary>
+    /// Returns the smallest rectangle that contains all of the specified screen bounds.
+    /// </summary>
     public static RectangleInfo GetCombinedScreenBounds(List<RectangleInfo> screenBounds)
     {
+        // we can't simply start with (0,0,0,0) and expand to encompass all screen bounds because
+        // (0,0,0,0) might not actually exist in the combined region - for example if
+        // "screenBounds = [(100, 100, 100, 100)]" we'd end up (incorrectly) with (0, 0, 200, 200).
+        // our actual approach is:
+        // * if the input is a single bounds we'll just return that
+        // * otherwise we use the *first* bounds as the seed for combining the remaining bounds
         return screenBounds.Skip(1).Aggregate(
             seed: screenBounds.First(),
             (combined, screenBounds) => combined.Union(screenBounds));
     }
 
+    /// <param name="maximumSize">
+    /// An optional upper bound on the layout's size.
+    /// If specified, device and screen dimensions will be scaled down as required in order for the final layout to fit inside the bounds.
+    /// If <see langword="null"/>, the layout size will be calculated to allow full-size device and screen visualisations.
+    /// </param>
+    /// <param name="statusBarHeight">
+    /// The height of the area to reserve at the bottom of the layout area (inside the outer border) to accomodate a status/tip bar strip.
+    /// </param>
     public static PreviewLayout GetPreviewLayout(
-        PreviewStyle previewStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen)
+        PreviewStyle previewStyle, DisplayInfo displayInfo, SizeInfo? maximumSize = null)
     {
         ArgumentNullException.ThrowIfNull(previewStyle);
         ArgumentNullException.ThrowIfNull(displayInfo);
-        ArgumentNullException.ThrowIfNull(activatedScreen);
 
-        /*
-
-           example layout:
-
-           +-------------------------------[host]-------------------------------+
-           |▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒[preview]▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒|
-           |▒▒+----------------------------[grid]----+----------------------+▒▒|
-           |▒▒|                                      |▓▓▓▓▓▓[device 2]▓▓▓▓▓▓|▒▒|
-           |▒▒|                                      |▓▓░░░░[screen 1]░░░░▓▓|▒▒|
-           |▒▒|▓▓▓▓▓▓▓▓▓▓▓▓▓▓[device 1]▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▓▓░░              ░░▓▓|▒▒|
-           |▒▒|▓▓░░░░[screen 1]░░░░░░[screen 2]░░░░▓▓|▓▓░░              ░░▓▓|▒▒|
-           |▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░              ░░▓▓|▒▒|
-           |▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░░░░░░░░░░░░░░░░░▓▓|▒▒|
-           |▒▒|▓▓░░              ░░              ░░▓▓|▓▓░░░░[screen 2]░░░░▓▓|▒▒|
-           |▒▒|▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▓▓|▓▓░░              ░░▓▓|▒▒|
-           |▒▒|▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▓▓░░              ░░▓▓|▒▒|
-           |▒▒|                                      |▓▓░░              ░░▓▓|▒▒|
-           |▒▒|                                      |▓▓░░░░░░░░░░░░░░░░░░▓▓|▒▒|
-           |▒▒|                                      |▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓|▒▒|
-           |▒▒+--------------------------------------+----------------------+▒▒|
-           |▒▒|        ▓▓▓▓▓▓[device 3]▓▓▓▓▓▓        |                      |▒▒|
-           |▒▒|        ▓▓░░░░[screen 1]░░░░▓▓        |                      |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |                      |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |   ▓▓▓[device 4]▓▓▓   |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |   ▓▓░[screen 1]░▓▓   |▒▒|
-           |▒▒|        ▓▓░░░░░░░░░░░░░░░░░░▓▓        |   ▓▓░░        ░░▓▓   |▒▒|
-           |▒▒|        ▓▓░░░░[screen 2]░░░░▓▓        |   ▓▓░░        ░░▓▓   |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |   ▓▓░░░░░░░░░░░░▓▓   |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |   ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓   |▒▒|
-           |▒▒|        ▓▓░░              ░░▓▓        |                      |▒▒|
-           |▒▒|        ▓▓░░░░░░░░░░░░░░░░░░▓▓        |                      |▒▒|
-           |▒▒|        ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓        |                      |▒▒|
-           |▒▒+--------------------------------------+----------------------+▒▒|
-           |▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒|
-           +-------------------------------------------------------------------+
-
-           the "host" box (margin/border only) is a hosting window's own
-           concern - see GetHostBoxStyle/GetHostBounds - everything from
-           "preview" inward is what this method actually returns.
-
-        */
-
-        var hostBoxStyle = LayoutHelper.GetHostBoxStyle(previewStyle.CanvasStyle);
-        var previewBoxStyle = LayoutHelper.GetPreviewBoxStyle(previewStyle.CanvasStyle);
+        var previewWindowStyle = LayoutHelper.GetPreviewWindowStyle(previewStyle.CanvasStyle);
+        var previewPaneStyle = LayoutHelper.GetPreviewPaneStyle(previewStyle.CanvasStyle);
 
         // arrange the preview, canvas, devices and screens
-        var previewLayout = LayoutHelper.CreateInitialPreviewLayout(previewStyle, previewBoxStyle, hostBoxStyle, displayInfo, activatedScreen);
+        var previewLayout = LayoutHelper.CreateInitialPreviewLayout(previewStyle, previewWindowStyle, previewPaneStyle, maximumSize);
+        LayoutHelper.AddDeviceAndScreenStyles(previewLayout, previewStyle, displayInfo);
         LayoutHelper.ArrangeAndScaleDeviceLayouts(previewLayout);
         LayoutHelper.ArrangeAndScaleScreenLayouts(previewLayout);
         LayoutHelper.ArrangeAndResizeCanvasLayout(previewLayout);
@@ -81,17 +126,18 @@ public static class LayoutHelper
     }
 
     /// <summary>
-    /// Positions an arbitrary rectangle (typically a hosting window's own outer bounds, from
-    /// wrapping a <see cref="PreviewLayout.PreviewSize"/> in <see cref="GetHostBoxStyle"/>) on
-    /// the desktop - centered on the activated location, clamped to stay fully within the
-    /// activated screen. <see cref="PreviewLayout"/> itself deliberately knows nothing about
-    /// desktop position - this is entirely a hosting window's own concern.
+    /// Positions an arbitrary rectangle (typically a PreviewWindow's own outer bounds) on
+    /// the desktop - centered on the activated location.
     /// </summary>
     public static RectangleInfo PositionOnScreen(RectangleInfo bounds, ScreenInfo activatedScreen, PointInfo activatedLocation)
     {
         ArgumentNullException.ThrowIfNull(bounds);
         ArgumentNullException.ThrowIfNull(activatedScreen);
         ArgumentNullException.ThrowIfNull(activatedLocation);
+
+        // center the bounds on the activated location, *but* if the activated location is
+        // near the edge of the screen that *could* cause the bounding box to fall partially
+        // outside the screen bounds so we'll nudge it back inside the screen bounds as well
         return bounds
             .Center(activatedLocation)
             .MoveInside(activatedScreen.DisplayArea);
@@ -103,7 +149,7 @@ public static class LayoutHelper
     /// zero padding since there's no gap between the border's inner edge and the preview
     /// pane's own content - the preview pane's background fills right up to its own edge.
     /// </summary>
-    public static BoxStyle GetHostBoxStyle(BoxStyle canvasStyle)
+    public static BoxStyle GetPreviewWindowStyle(BoxStyle canvasStyle)
     {
         ArgumentNullException.ThrowIfNull(canvasStyle);
         return new BoxStyle(
@@ -116,10 +162,10 @@ public static class LayoutHelper
     /// <summary>
     /// Derives the box style a <see cref="PreviewLayout"/> uses for its own content - zero
     /// margin and border (both are now the hosting window's job, see
-    /// <see cref="GetHostBoxStyle"/>) and the padding/background the preview pane renders
+    /// <see cref="GetPreviewWindowStyle"/>) and the padding/background the preview pane renders
     /// itself, inset from its own bounds.
     /// </summary>
-    public static BoxStyle GetPreviewBoxStyle(BoxStyle canvasStyle)
+    public static BoxStyle GetPreviewPaneStyle(BoxStyle canvasStyle)
     {
         ArgumentNullException.ThrowIfNull(canvasStyle);
         return new BoxStyle(
@@ -130,28 +176,85 @@ public static class LayoutHelper
     }
 
     /// <summary>
-    /// Computes a hosting window's own wrapping box - margin, border, and a content box that
-    /// exactly matches <paramref name="previewBounds"/> - both zero-based, since
-    /// <see cref="PreviewLayout"/> (and everything nested under it) has no notion of desktop
-    /// position, only size (see <see cref="PreviewLayout.PreviewSize"/>). A hosting window
-    /// uses this both to work out its own on-screen footprint size (typically passing
-    /// <c>new RectangleInfo(previewLayout.PreviewSize)</c>, then positioning the result with
-    /// <see cref="PositionOnScreen"/>) and to work out where to render the border image
-    /// (passing <see cref="CanvasLayout.CanvasBounds"/>'s <c>OuterBounds</c> instead, since
-    /// that's also zero-based and rendering happens into a bitmap of its own).
+    /// Takes the size of a PreviewPane's layout and uses it as the baseline for calculating the
+    /// containing PreviewWindow's size. Effectively adds the outer border and margin onto the
+    /// PreviewPane size.
     /// </summary>
-    public static BoxBounds GetHostBounds(RectangleInfo previewBounds, BoxStyle hostBoxStyle)
+    public static BoxBounds GetPreviewWindowBounds(SizeInfo previewSize, BoxStyle previewWindowStyle)
     {
-        ArgumentNullException.ThrowIfNull(previewBounds);
-        ArgumentNullException.ThrowIfNull(hostBoxStyle);
-        return BoxBounds.CreateFromContentBounds(
-            contentBounds: previewBounds,
-            boxStyle: hostBoxStyle);
+        ArgumentNullException.ThrowIfNull(previewSize);
+        ArgumentNullException.ThrowIfNull(previewWindowStyle);
+        var contentBounds = new RectangleInfo(0, 0, previewSize.Width, previewSize.Height);
+        return LayoutHelper.GetPreviewWindowBounds(contentBounds, previewWindowStyle);
     }
 
-    internal static PreviewLayout.Builder CreateInitialPreviewLayout(
-        PreviewStyle previewStyle, BoxStyle previewBoxStyle, BoxStyle hostBoxStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen)
+    /// <summary>
+    /// Takes the bounds of a PreviewPane's layout and uses it as the baseline
+    /// for calculating the containing PreviewWindow's size. Effectively adds
+    /// the outer border and margin onto the PreviewPane size and includes room
+    /// for a status bar of given height.
+    /// </summary>
+    public static BoxBounds GetPreviewWindowBounds(RectangleInfo previewBounds, BoxStyle previewWindowStyle)
     {
+        ArgumentNullException.ThrowIfNull(previewBounds);
+        ArgumentNullException.ThrowIfNull(previewWindowStyle);
+        return BoxBounds.CreateFromContentBounds(
+            contentBounds: previewBounds,
+            boxStyle: previewWindowStyle);
+    }
+
+    /// <summary>
+    /// Works out the maximum window and pane sizes for the given constraints, and returns a
+    /// <see cref="PreviewLayout.Builder"/> seeded with just <see cref="PreviewLayout.Builder.PreviewSize"/>
+    /// and the canvas's own bounds/style - no devices yet, see <see cref="AddDeviceAndScreenStyles"/>.
+    /// </summary>
+    internal static PreviewLayout.Builder CreateInitialPreviewLayout(
+        PreviewStyle previewStyle, BoxStyle previewWindowStyle, BoxStyle previewPaneStyle, SizeInfo? maximumSize = null)
+    {
+        ArgumentNullException.ThrowIfNull(previewStyle);
+
+        // work out the maximum allowed size of the *window's* outer footprint:
+        // * can't be bigger than maximumSize, if the caller gave one (e.g. the activated screen,
+        //   for a caller rendering a real on-screen window)
+        // * can't be bigger than the configured canvas size
+        var windowMaxSize = (maximumSize is not null)
+            ? previewStyle.CanvasSize.Clamp(maximumSize)
+            : previewStyle.CanvasSize;
+
+        // the preview pane's own maximum size is whatever's left of that footprint once the
+        // window's margin/border allowance has been subtracted from it - pure size arithmetic,
+        // since PreviewLayout deliberately has no position, only a size (see PreviewLayout).
+        var paneMaxSize = windowMaxSize
+            .Shrink(previewWindowStyle.MarginStyle)
+            .Shrink(previewWindowStyle.BorderStyle);
+        var paneMaxBounds = new RectangleInfo(paneMaxSize);
+
+        // this is the root of a nested structure of mutable "builder" objects that can be used
+        // to build the final immutable layout objects once all the bounds have been calculated
+        return new PreviewLayout.Builder
+        {
+            PreviewSize = SizeInfo.Empty,
+            CanvasLayout = new()
+            {
+                CanvasBounds = BoxBounds.CreateFromOuterBounds(
+                    outerBounds: paneMaxBounds,
+                    boxStyle: previewPaneStyle),
+                CanvasStyle = previewPaneStyle,
+            },
+        };
+    }
+
+    /// <summary>
+    /// Populates <paramref name="previewLayout"/>'s device/screen layouts - one
+    /// <see cref="DeviceLayout.Builder"/> per <paramref name="displayInfo"/> device, each with
+    /// its screens' styles already resolved (see its own local <c>GetDeviceScreenColor</c>) but their
+    /// bounds still <see cref="BoxBounds.Empty"/> placeholders, ready for
+    /// <see cref="ArrangeAndScaleDeviceLayouts"/>/<see cref="ArrangeAndScaleScreenLayouts"/> to
+    /// arrange for real.
+    /// </summary>
+    internal static void AddDeviceAndScreenStyles(PreviewLayout.Builder previewLayout, PreviewStyle previewStyle, DisplayInfo displayInfo)
+    {
+        ArgumentNullException.ThrowIfNull(previewLayout);
         ArgumentNullException.ThrowIfNull(previewStyle);
         ArgumentNullException.ThrowIfNull(displayInfo);
 
@@ -161,88 +264,51 @@ public static class LayoutHelper
             throw new ArgumentException("Value must contain at least one device.", nameof(displayInfo));
         }
 
-        // work out the maximum allowed size of the *host's* outer footprint:
-        // * can't be bigger than the activated screen
-        // * can't be bigger than the configured canvas size
-        var hostMaxSize = previewStyle.CanvasSize
-            .Clamp(activatedScreen.DisplayArea.Size);
+        var canvasLayout = previewLayout.CanvasLayout
+            ?? throw new InvalidOperationException();
 
-        // the preview pane's own maximum size is whatever's left of that footprint once the
-        // host's margin/border allowance has been subtracted from it - pure size arithmetic,
-        // since PreviewLayout deliberately has no position, only a size (see PreviewLayout).
-        var previewMaxSize = hostMaxSize
-            .Shrink(hostBoxStyle.MarginStyle)
-            .Shrink(hostBoxStyle.BorderStyle);
-        var previewMaxBounds = new RectangleInfo(previewMaxSize);
-
-        var screenStyles = LayoutHelper.GetDeviceScreenStyles(previewStyle, displayInfo.Devices.Count).ToList();
-
-        // create an initial preview layout.
-        // this is a nested structure of mutable "builder" objects that can be used to
-        // build the final immutable layout objects once all the bounds have been calculated
-        var previewLayout = new PreviewLayout.Builder
-        {
-            PreviewSize = SizeInfo.Empty,
-            CanvasLayout = new()
+        canvasLayout.DeviceLayouts = displayInfo.Devices.Select(
+            (deviceInfo, deviceIndex) =>
             {
-                CanvasBounds = BoxBounds.CreateFromOuterBounds(
-                    outerBounds: previewMaxBounds,
-                    boxStyle: previewBoxStyle),
-                CanvasStyle = previewBoxStyle,
-                DeviceLayouts = displayInfo.Devices.Select(
-                    (deviceInfo, deviceIndex) => new DeviceLayout.Builder
-                    {
-                        DeviceInfo = deviceInfo,
-                        DeviceBounds = BoxBounds.Empty,
-                        DeviceStyle = BoxStyle.Empty,
-                        ScreenLayouts = deviceInfo.Screens.Select(
-                            screenInfo => new ScreenLayout.Builder
-                            {
-                                ScreenInfo = screenInfo,
-                                ScreenBounds = BoxBounds.Empty,
-                                ScreenStyle = screenStyles[deviceIndex],
-                            }).ToList(),
-                    }).ToList(),
-            },
-        };
+                // the first device (index 0, assumed to be "localhost") gets the configured screen
+                // border colour; every other device cycles through ExtraColors (repeating from
+                // the start once exhausted), falling back to the configured colour if none are
+                // configured.
+                var borderColor = (deviceIndex == 0 || previewStyle.ExtraColors.Count == 0)
+                    ? previewStyle.ScreenStyle.BorderStyle.Color
+                    : previewStyle.ExtraColors[(deviceIndex - 1) % previewStyle.ExtraColors.Count];
 
-        return previewLayout;
-    }
-
-    internal static IEnumerable<BoxStyle> GetDeviceScreenStyles(PreviewStyle previewStyle, int screenCount)
-    {
-        // work out the colors to use for the screen borders for each device
-        // (add the default localhost color first and then loop over the extra colors until we've got enough)
-        var screenBorderColors = new List<Color?> { previewStyle.ScreenStyle.BorderStyle.Color };
-        while (screenBorderColors.Count < screenCount)
-        {
-            if (previewStyle.ExtraColors?.Count > 0)
-            {
-                screenBorderColors.AddRange(previewStyle.ExtraColors.Cast<Color?>());
-                continue;
-            }
-
-            screenBorderColors.Add(previewStyle.ScreenStyle.BorderStyle.Color);
-        }
-
-        // convert the colors into screen styles
-        // note - only create a new ScreenStyle if the border color is different.
-        // (this is to preserve a reference to ScreenStyle.Empty - and
-        // "ScreenStyle.IsEmpty == true" - if the new border color is Transparent)
-        return screenBorderColors
-            .Take(screenCount)
-            .Select(
-                color => previewStyle.ScreenStyle.BorderStyle.Color == color
+                // only create a new ScreenStyle if the border color is different from the
+                // configured one - this preserves a reference to the configured ScreenStyle
+                // (and its own "ScreenStyle.IsEmpty == true" if the color is Transparent)
+                // rather than always allocating a fresh, effectively-identical copy.
+                var screenStyle = previewStyle.ScreenStyle.BorderStyle.Color == borderColor
                     ? previewStyle.ScreenStyle
                     : new BoxStyle(
                         previewStyle.ScreenStyle.MarginStyle,
-                        previewStyle.ScreenStyle.BorderStyle.WithColor(color),
+                        previewStyle.ScreenStyle.BorderStyle.WithColor(borderColor),
                         previewStyle.ScreenStyle.PaddingStyle,
-                        previewStyle.ScreenStyle.BackgroundStyle));
+                        previewStyle.ScreenStyle.BackgroundStyle);
+
+                return new DeviceLayout.Builder
+                {
+                    DeviceInfo = deviceInfo,
+                    DeviceBounds = BoxBounds.Empty,
+                    DeviceStyle = BoxStyle.Empty,
+                    ScreenLayouts = deviceInfo.Screens.Select(
+                        screenInfo => new ScreenLayout.Builder
+                        {
+                            ScreenInfo = screenInfo,
+                            ScreenBounds = BoxBounds.Empty,
+                            ScreenStyle = screenStyle,
+                        }).ToList(),
+                };
+            }).ToList();
     }
 
     /// <summary>
-    /// Arranges the device layouts into a non-overlapping grid and scales them to fit inside the specified content bounds.
+    /// Arranges the device layouts into a non-overlapping grid and scales them
+    /// so the grid fits inside the specified content bounds.
     /// </summary>
     internal static void ArrangeAndScaleDeviceLayouts(PreviewLayout.Builder previewLayout)
     {
@@ -434,6 +500,10 @@ public static class LayoutHelper
         }
     }
 
+    /// <summary>
+    /// Crops the layout's canvas bounds to tightly wrap the contained device layouts
+    /// and moves it back to the same origin it started at.
+    /// </summary>
     internal static void ArrangeAndResizeCanvasLayout(PreviewLayout.Builder previewLayout)
     {
         var canvasLayout = previewLayout.CanvasLayout ?? throw new InvalidOperationException();

--- a/src/FancyMouse.Common/Helpers/MouseHelper.cs
+++ b/src/FancyMouse.Common/Helpers/MouseHelper.cs
@@ -1,7 +1,6 @@
 ﻿using FancyMouse.Common.Win32Gen;
 using FancyMouse.Models.Drawing;
 
-using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Windows.Win32.UI.WindowsAndMessaging;
 

--- a/src/FancyMouse.HotKeys/HotKeyManager.cs
+++ b/src/FancyMouse.HotKeys/HotKeyManager.cs
@@ -58,7 +58,7 @@ public sealed class HotKeyManager
         return (HWND)(this.Window?.Hwnd ?? throw new InvalidOperationException());
     }
 
-    public void SetHoKey(Keystroke? hotKey)
+    public void SetHotKey(Keystroke? hotKey)
     {
         var hwnd = new Lazy<HWND>(() => this.GetHwndOrThrow());
 

--- a/src/FancyMouse.Models/Layout/PreviewLayout.cs
+++ b/src/FancyMouse.Models/Layout/PreviewLayout.cs
@@ -7,7 +7,7 @@ namespace FancyMouse.Models.Layout;
 /// the outer border and not a position on the desktop. Deliberately excludes the border:
 /// that's a hosting-window concern (drawn by whatever hosts the preview pane, wrapping around
 /// <see cref="PreviewSize"/> with its own margin/border box - see
-/// <c>LayoutHelper.GetHostBoxStyle</c>), not something the preview pane's own layout needs to
+/// <c>LayoutHelper.GetPreviewWindowStyle</c>), not something the preview pane's own layout needs to
 /// know about. Deliberately excludes desktop position too - every bounds in
 /// <see cref="CanvasLayout"/> (and everything nested under it) is relative to this content's
 /// own top-left corner as the origin; deciding where that origin actually lands on the

--- a/src/FancyMouse.Settings.UnitTests/AppSettingsReaderTests.cs
+++ b/src/FancyMouse.Settings.UnitTests/AppSettingsReaderTests.cs
@@ -22,19 +22,34 @@ public sealed class AppSettingsReaderTests
         }
 
         [TestMethod]
-        public void EmptyJsonShouldReturnDefaultSettings()
+        public void EmptyJsonShouldThrow()
         {
-            var actual = AppSettingsReader.ParseJson(string.Empty);
-            var expected = AppSettings.DefaultSettings;
-            Assert.AreSame(expected, actual);
+            // the concrete exception System.Text.Json throws for malformed JSON
+            // (JsonReaderException) is an internal type, so we can only assert
+            // against its public JsonException base.
+            try
+            {
+                AppSettingsReader.ParseJson(string.Empty);
+                Assert.Fail("Expected a JsonException to be thrown.");
+            }
+            catch (JsonException)
+            {
+                // expected
+            }
         }
 
         [TestMethod]
-        public void InvalidJsonShouldReturnDefaultSettings()
+        public void InvalidJsonShouldThrow()
         {
-            var actual = AppSettingsReader.ParseJson("xxx");
-            var expected = AppSettings.DefaultSettings;
-            Assert.AreSame(expected, actual);
+            try
+            {
+                AppSettingsReader.ParseJson("xxx");
+                Assert.Fail("Expected a JsonException to be thrown.");
+            }
+            catch (JsonException)
+            {
+                // expected
+            }
         }
 
         [TestMethod]

--- a/src/FancyMouse.Settings/AppSettingsReader.cs
+++ b/src/FancyMouse.Settings/AppSettingsReader.cs
@@ -22,18 +22,10 @@ public static class AppSettingsReader
         }
 
         // determine the version of the config file so we know which converter to use
-        int configVersion;
-        try
-        {
-            var configNode = JsonNode.Parse(configJson);
+        var configNode = JsonNode.Parse(configJson);
 
-            // if the version isn't specified we'll default to v1
-            configVersion = configNode?["version"]?.GetValue<int>() ?? 1;
-        }
-        catch
-        {
-            return AppSettings.DefaultSettings;
-        }
+        // if the version isn't specified we'll default to v1
+        var configVersion = configNode?["version"]?.GetValue<int>() ?? 1;
 
         var appSettings = configVersion switch
         {

--- a/src/FancyMouse.WinUI3/App.xaml.cs
+++ b/src/FancyMouse.WinUI3/App.xaml.cs
@@ -72,12 +72,13 @@ public partial class App : Application
 
         try
         {
-            var previewWindow = new PreviewWindow(logger: logger);
+            var configHelper = new ConfigHelper(logger);
+            var previewWindow = new PreviewWindow(logger: logger, configHelper: configHelper);
 
             this.VerifyHighDpiMode(logger);
-            this.InitializeAppSettings(logger);
-            this.InitializeTelemetry(timestamp);
-            this.InitializeHotkey(logger, previewWindow);
+            this.InitializeAppSettings(logger, configHelper);
+            this.InitializeTelemetry(timestamp, configHelper);
+            this.InitializeHotkey(logger, previewWindow, configHelper);
             this.InitializeTrayIcon();
         }
         catch (Exception ex)
@@ -127,17 +128,17 @@ public partial class App : Application
     /// Must run before <see cref="InitializeTelemetry"/>, which depends on
     /// <see cref="ConfigHelper.AppSettings"/> being populated already.
     /// </summary>
-    private void InitializeAppSettings(Logger logger)
+    private void InitializeAppSettings(Logger logger, ConfigHelper configHelper)
     {
         var appSettingsPath = ".\\appSettings.json";
         logger.Info(CultureInfo.InvariantCulture, "settings path = {appSettingsPath}", appSettingsPath);
-        ConfigHelper.SetAppSettingsPath(appSettingsPath);
+        configHelper.SetAppSettingsPath(appSettingsPath);
 
         // load the application settings and start the filesystem watcher
         // so we can automatically reload settings if they change on disk
         logger.Info("loading app settings");
-        ConfigHelper.LoadAppSettings();
-        ConfigHelper.StartAppSettingsWatcher();
+        configHelper.LoadAppSettings();
+        configHelper.StartAppSettingsWatcher();
         logger.Info("loaded app settings");
     }
 
@@ -149,11 +150,11 @@ public partial class App : Application
     /// Must run after <see cref="ConfigHelper.LoadAppSettings"/>, since it depends on
     /// <see cref="ConfigHelper.AppSettings"/> being populated already.
     /// </summary>
-    private void InitializeTelemetry(DateTime timestamp)
+    private void InitializeTelemetry(DateTime timestamp, ConfigHelper configHelper)
     {
         Telemetry.SetCurrent(TelemetryContext.Create(nameof(FancyMouse)));
 
-        if (ConfigHelper.AppSettings?.TelemetryEnabled == true)
+        if (configHelper.AppSettings?.TelemetryEnabled == true)
         {
             var telemetryPath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -175,11 +176,11 @@ public partial class App : Application
     /// window's UI state at the same time, which is visible as a brief white flash before the
     /// correct content redraws.
     /// </summary>
-    private void InitializeHotkey(Logger logger, PreviewWindow previewWindow)
+    private void InitializeHotkey(Logger logger, PreviewWindow previewWindow, ConfigHelper configHelper)
     {
         logger.Info("starting hotkey handler");
 
-        ConfigHelper.SetHotKeyEventHandler(
+        configHelper.SetHotKeyEventHandler(
             (_, _) =>
             {
                 // invoke on the thread the form was created on. this avoids

--- a/src/FancyMouse.WinUI3/Internal/Helpers/ConfigHelper.cs
+++ b/src/FancyMouse.WinUI3/Internal/Helpers/ConfigHelper.cs
@@ -1,47 +1,52 @@
-﻿using FancyMouse.HotKeys;
+using System.Text.Json;
+
+using FancyMouse.HotKeys;
 using FancyMouse.Settings;
 
 namespace FancyMouse.WinUI3.Internal.Helpers;
 
-internal static class ConfigHelper
+internal sealed class ConfigHelper : IDisposable
 {
-    private static readonly HotKeyManager _hotKeyManager;
+    private readonly NLog.ILogger _logger;
 
-    private static FileSystemWatcher? _appSettingsWatcher;
+    private readonly HotKeyManager _hotKeyManager;
 
-    private static AppSettings? _appSettings;
-    private static EventHandler<HotKeyEventArgs>? _hotKeyPressed;
+    private FileSystemWatcher? _appSettingsWatcher;
 
-    static ConfigHelper()
+    private AppSettings? _appSettings;
+    private EventHandler<HotKeyEventArgs>? _hotKeyPressed;
+
+    public ConfigHelper(NLog.ILogger logger)
     {
-        ConfigHelper._hotKeyManager = new HotKeyManager();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _hotKeyManager = new HotKeyManager();
     }
 
-    public static string? AppSettingsPath
+    public string? AppSettingsPath
     {
         get;
         private set;
     }
 
-    public static AppSettings? AppSettings
+    public AppSettings? AppSettings
     {
         get
         {
             if (_appSettings is null)
             {
-                ConfigHelper.LoadAppSettings();
+                this.LoadAppSettings();
             }
 
             return _appSettings;
         }
     }
 
-    public static void SetAppSettingsPath(string appSettingsPath)
+    public void SetAppSettingsPath(string appSettingsPath)
     {
-        ConfigHelper.AppSettingsPath = appSettingsPath;
+        this.AppSettingsPath = appSettingsPath;
     }
 
-    public static void SetHotKeyEventHandler(EventHandler<HotKeyEventArgs> eventHandler)
+    public void SetHotKeyEventHandler(EventHandler<HotKeyEventArgs> eventHandler)
     {
         var evt = _hotKeyPressed;
         if (evt is not null)
@@ -53,50 +58,65 @@ internal static class ConfigHelper
         _hotKeyManager.HotKeyPressed += eventHandler;
     }
 
-    public static void LoadAppSettings()
+    public void LoadAppSettings()
     {
-        _hotKeyManager.SetHoKey(null);
-        _appSettings = AppSettingsReader.ReadFile(ConfigHelper.AppSettingsPath
+        _hotKeyManager.SetHotKey(null);
+        _appSettings = AppSettingsReader.ReadFile(this.AppSettingsPath
             ?? throw new InvalidOperationException("AppSettings cannot be null"));
-        _hotKeyManager.SetHoKey(_appSettings.Hotkey
+        _hotKeyManager.SetHotKey(_appSettings.Hotkey
             ?? throw new InvalidOperationException($"{nameof(_appSettings.Hotkey)} cannot be null"));
     }
 
-    public static void StartAppSettingsWatcher()
+    public void StartAppSettingsWatcher()
     {
         // set up the filesystem watcher
-        var path = Path.GetDirectoryName(ConfigHelper.AppSettingsPath) ?? throw new InvalidOperationException();
-        var filter = Path.GetFileName(ConfigHelper.AppSettingsPath) ?? throw new InvalidOperationException();
+        var path = Path.GetDirectoryName(this.AppSettingsPath) ?? throw new InvalidOperationException();
+        var filter = Path.GetFileName(this.AppSettingsPath) ?? throw new InvalidOperationException();
         _appSettingsWatcher = new FileSystemWatcher(path, filter)
         {
             NotifyFilter = NotifyFilters.LastWrite,
             EnableRaisingEvents = true,
         };
-        _appSettingsWatcher.Changed += ConfigHelper.OnAppSettingsChanged;
+        _appSettingsWatcher.Changed += this.OnAppSettingsChanged;
     }
 
-    private static void OnAppSettingsChanged(object sender, FileSystemEventArgs e)
+    private void OnAppSettingsChanged(object sender, FileSystemEventArgs e)
     {
         if (e.ChangeType != WatcherChangeTypes.Changed)
         {
             return;
         }
 
-        // the file might not have been released yet by the application that saved it
-        // and caused the file system event (e.g. notepad) so we need to do a couple
-        // of retries to give it a chance to release the lock so we can load the file contents.
-        for (var i = 0; i < 3; i++)
+        try
         {
-            try
+            // the file might not have been released yet by the application that saved it
+            // and caused the file system event (e.g. notepad) so we need to do a couple
+            // of retries to give it a chance to release the lock so we can load the file contents.
+            for (var i = 0; i < 3; i++)
             {
-                ConfigHelper.LoadAppSettings();
-                break;
-            }
-            catch (IOException ex)
-            {
-                Console.WriteLine(ex.ToString());
-                Thread.Sleep(250);
+                try
+                {
+                    this.LoadAppSettings();
+                    break;
+                }
+                catch (IOException ex)
+                {
+                    _logger.Error(ex, "failed to reload app settings, retrying");
+                    Thread.Sleep(250);
+                }
             }
         }
+        catch (JsonException ex)
+        {
+            // the saved file isn't valid config - retrying won't fix malformed JSON, so just
+            // log it and keep whatever settings were already loaded, rather than let the
+            // exception vanish silently into FileSystemWatcher's own event dispatch.
+            _logger.Error(ex, "failed to reload app settings - config file contains invalid JSON");
+        }
+    }
+
+    public void Dispose()
+    {
+        _appSettingsWatcher?.Dispose();
     }
 }

--- a/src/FancyMouse.WinUI3/UI/NavigateToEventArgs.cs
+++ b/src/FancyMouse.WinUI3/UI/NavigateToEventArgs.cs
@@ -4,10 +4,10 @@ using FancyMouse.Models.Drawing;
 namespace FancyMouse.WinUI3.UI;
 
 /// <summary>
-/// Carries the intent behind a screen click, or a keyboard shortcut that means the same thing
-/// (1-9, arrow keys, P, Home, End) - "move the pointer to this location on this device". Mouse
-/// and keyboard both resolve to the exact same event so the host only needs one handler for
-/// either.
+/// Implements the NavigateTo event that is used by the PreviewWinow to signal
+/// to the hosting application that to user wants to move the cursor to a specific
+/// location. Can be raised as the result of a mouse click on the preview window,
+/// or a keyboard shortcut that means the same thing (e.g. 1-9, arrow keys, P, Home, End)
 /// </summary>
 public sealed class NavigateToEventArgs : EventArgs
 {

--- a/src/FancyMouse.WinUI3/UI/NavigateToEventArgs.cs
+++ b/src/FancyMouse.WinUI3/UI/NavigateToEventArgs.cs
@@ -4,8 +4,8 @@ using FancyMouse.Models.Drawing;
 namespace FancyMouse.WinUI3.UI;
 
 /// <summary>
-/// Implements the NavigateTo event that is used by the PreviewWinow to signal
-/// to the hosting application that to user wants to move the cursor to a specific
+/// Implements the NavigateTo event that is used by the PreviewWindow to signal
+/// to the hosting application that the user wants to move the cursor to a specific
 /// location. Can be raised as the result of a mouse click on the preview window,
 /// or a keyboard shortcut that means the same thing (e.g. 1-9, arrow keys, P, Home, End)
 /// </summary>

--- a/src/FancyMouse.WinUI3/UI/PreviewPane.input.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewPane.input.cs
@@ -8,11 +8,6 @@ using Windows.System;
 
 namespace FancyMouse.WinUI3.UI;
 
-/// <summary>
-/// The half of <see cref="PreviewPane"/> that turns raw mouse/keyboard input into navigation
-/// intent - see <see cref="NavigateTo"/>/<see cref="Cancel"/> - so the host doesn't need its own
-/// copy of "which screen is that" or "which screen is next" logic.
-/// </summary>
 public sealed partial class PreviewPane
 {
     private void PreviewPane_PointerPressed(object sender, PointerRoutedEventArgs e)

--- a/src/FancyMouse.WinUI3/UI/PreviewPane.layout.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewPane.layout.cs
@@ -14,10 +14,6 @@ using Image = Microsoft.UI.Xaml.Controls.Image;
 
 namespace FancyMouse.WinUI3.UI;
 
-/// <summary>
-/// The half of <see cref="PreviewPane"/> concerned with building/positioning the bezel and
-/// placeholder visuals called for by a new <see cref="Layout"/>.
-/// </summary>
 public sealed partial class PreviewPane
 {
     private static void OnLayoutChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
@@ -40,7 +36,7 @@ public sealed partial class PreviewPane
         this.Width = (double)bounds.Width / scale;
         this.Height = (double)bounds.Height / scale;
 
-        using var backgroundBitmap = DrawingHelper.RenderBackground(layout.CanvasLayout);
+        using var backgroundBitmap = DrawingHelper.RenderBackground(bounds.Size, layout.CanvasLayout.CanvasStyle.BackgroundStyle);
         this.BackgroundImage.Source = MediaHelper.ToBitmapImage(backgroundBitmap);
 
         var newScreenLayouts = layout.CanvasLayout.DeviceLayouts
@@ -81,7 +77,7 @@ public sealed partial class PreviewPane
                 // property writes, no re-render) and keeps that in sync even though the
                 // visuals themselves are being reused as-is.
                 var screenBounds = screenLayout.ScreenBounds;
-                PreviewPane.PositionElement(previousSlot.BezelImage, screenBounds.OuterBounds, scale);
+                PreviewPane.PositionElement(previousSlot.BezelImage, screenBounds.BorderBounds, scale);
                 if (previousSlot.PlaceholderRectangle is not null)
                 {
                     PreviewPane.PositionElement(previousSlot.PlaceholderRectangle, screenBounds.PaddingBounds, scale);
@@ -125,7 +121,7 @@ public sealed partial class PreviewPane
         && previous.ScreenStyle.BackgroundStyle.Color1 == current.ScreenStyle.BackgroundStyle.Color1;
 
     private static bool CanReuse(BoxBounds previous, BoxBounds current)
-        => PreviewPane.CanReuse(previous.OuterBounds, current.OuterBounds)
+        => PreviewPane.CanReuse(previous.BorderBounds, current.BorderBounds)
         && PreviewPane.CanReuse(previous.PaddingBounds, current.PaddingBounds)
         && PreviewPane.CanReuse(previous.ContentBounds, current.ContentBounds);
 
@@ -175,14 +171,14 @@ public sealed partial class PreviewPane
 
         Image bezelImage;
         using (var bezelBitmap = DrawingHelper.RenderBorder(
-            screenBounds.MoveTo(new PointInfo(0, 0)), screenLayout.ScreenStyle))
+            screenBounds.BorderBounds.Size, screenLayout.ScreenStyle.BorderStyle))
         {
             bezelImage = new Image
             {
                 Source = MediaHelper.ToBitmapImage(bezelBitmap),
                 Stretch = Stretch.Fill,
             };
-            PreviewPane.PositionElement(bezelImage, screenBounds.OuterBounds, scale);
+            PreviewPane.PositionElement(bezelImage, screenBounds.BorderBounds, scale);
             this.ScreensCanvas.Children.Add(bezelImage);
         }
 

--- a/src/FancyMouse.WinUI3/UI/PreviewPane.xaml.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewPane.xaml.cs
@@ -7,19 +7,6 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace FancyMouse.WinUI3.UI;
 
-/// <summary>
-/// Encapsulates the preview pane's own content - the background rectangle and the
-/// bezels/screenshots on top of it. Deliberately excludes the outer border, which is the
-/// hosting window's responsibility (see <see cref="Common.Helpers.LayoutHelper.GetPreviewWindowStyle"/>).
-/// The hosting window supplies the pre-computed <see cref="Layout"/> (this control doesn't
-/// calculate its own size); the background image and each screen's bezel are rendered
-/// internally from <see cref="Layout"/> as soon as it's set, and each screen starts out
-/// showing a placeholder fill until the hosting window backfills its real screenshot via
-/// <see cref="SetScreenshot"/> (screenshot capture needs the host's own capture pipeline,
-/// which this control has no access to). This control also owns turning raw mouse/keyboard
-/// input into navigation intent - see <see cref="NavigateTo"/>/<see cref="Cancel"/> - so the
-/// host doesn't need its own copy of "which screen is that" or "which screen is next" logic.
-/// </summary>
 public sealed partial class PreviewPane : UserControl
 {
     public static readonly DependencyProperty LayoutProperty = DependencyProperty.Register(
@@ -35,14 +22,13 @@ public sealed partial class PreviewPane : UserControl
         new PropertyMetadata(null));
 
     /// <summary>
-    /// Generates and retains each screen's blurred stand-in placeholder, keyed by physical
-    /// screen rather than layout position - see <see cref="ScreenshotBlurPipeline"/>. One long-lived
-    /// instance for this control's whole lifetime; <see cref="ApplyLayout"/> tells it which
-    /// screens currently exist (<see cref="ScreenshotBlurPipeline.SetActiveScreens"/>) once per activation.
+    /// A pipeline for generating the blurred screenshots that are shown
+    /// while the latest screenshot is being captured if a screen capture
+    /// takes more than the budget allowed to show the form.
     /// </summary>
     private readonly ScreenshotBlurPipeline blurPipeline = new();
 
-    private List<ScreenSlot> screenSlots = new();
+    private List<ScreenSlot> screenSlots = [];
 
     /// <summary>
     /// How long <see cref="CrossfadeContent"/> takes to fade a screen's content in. Short enough

--- a/src/FancyMouse.WinUI3/UI/PreviewPane.xaml.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewPane.xaml.cs
@@ -10,7 +10,7 @@ namespace FancyMouse.WinUI3.UI;
 /// <summary>
 /// Encapsulates the preview pane's own content - the background rectangle and the
 /// bezels/screenshots on top of it. Deliberately excludes the outer border, which is the
-/// hosting window's responsibility (see <see cref="Common.Helpers.LayoutHelper.GetHostBoxStyle"/>).
+/// hosting window's responsibility (see <see cref="Common.Helpers.LayoutHelper.GetPreviewWindowStyle"/>).
 /// The hosting window supplies the pre-computed <see cref="Layout"/> (this control doesn't
 /// calculate its own size); the background image and each screen's bezel are rendered
 /// internally from <see cref="Layout"/> as soon as it's set, and each screen starts out

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
@@ -121,16 +121,16 @@ public sealed partial class PreviewWindow
     /// through rendering it. The caller passes these straight back into
     /// <see cref="ShowWindowAsync"/>.
     /// </returns>
-    private async Task<(int Width, int Height, int CornerRadius)> RenderBorderAsync(PreviewLayout previewLayout, BoxStyle hostBoxStyle)
+    private async Task<(int Width, int Height, int CornerRadius)> RenderBorderAsync(PreviewLayout previewLayout, BoxStyle previewWindowStyle)
     {
         // render against a zero-based host box - a border image is its own bitmap, so its
         // pixel coordinates need to start at (0,0) regardless of where the (possibly
         // negative, once enlarged outward from a zero-based content box) host bounds would
         // otherwise place it.
-        var localHostBounds = LayoutHelper.GetPreviewWindowBounds(previewLayout.CanvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
+        var localHostBounds = LayoutHelper.GetPreviewWindowBounds(previewLayout.CanvasLayout.CanvasBounds.OuterBounds, previewWindowStyle)
             .MoveTo(new PointInfo(0, 0));
 
-        using var borderBitmap = DrawingHelper.RenderBorder(localHostBounds.BorderBounds.Size, hostBoxStyle.BorderStyle);
+        using var borderBitmap = DrawingHelper.RenderBorder(localHostBounds.BorderBounds.Size, previewWindowStyle.BorderStyle);
 
         await this.InvokeOnUiThreadAsync(
             () =>
@@ -142,13 +142,15 @@ public sealed partial class PreviewWindow
 
                 // position PreviewPane so it lines up exactly with the transparent hole in
                 // the middle of the border image - the offset is always the host box's own
-                // border thickness, regardless of where localHostBounds itself sits.
+                // border+padding thickness (margin is excluded - RenderBorder's bitmap starts
+                // at the border's own outer edge, not the margin's), regardless of where
+                // localHostBounds itself sits.
                 var offsetX = (localHostBounds.ContentBounds.X - localHostBounds.BorderBounds.X) * (decimal)highDpiScalingRatio;
                 var offsetY = (localHostBounds.ContentBounds.Y - localHostBounds.BorderBounds.Y) * (decimal)highDpiScalingRatio;
                 this.PreviewPane.Margin = new Thickness((double)offsetX, (double)offsetY, 0, 0);
             }).ConfigureAwait(false);
 
-        return (borderBitmap.Width, borderBitmap.Height, (int)hostBoxStyle.BorderStyle.Left);
+        return (borderBitmap.Width, borderBitmap.Height, (int)previewWindowStyle.BorderStyle.Left);
     }
 
     private async Task SetPreviewPaneLayoutAsync(PreviewLayout previewLayout, ScreenInfo activatedScreen)

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
@@ -127,7 +127,7 @@ public sealed partial class PreviewWindow
         // pixel coordinates need to start at (0,0) regardless of where the (possibly
         // negative, once enlarged outward from a zero-based content box) host bounds would
         // otherwise place it.
-        var localHostBounds = LayoutHelper.GetHostBounds(previewLayout.CanvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
+        var localHostBounds = LayoutHelper.GetPreviewWindowBounds(previewLayout.CanvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
             .MoveTo(new PointInfo(0, 0));
 
         using var borderBitmap = DrawingHelper.RenderBorder(localHostBounds.BorderBounds.Size, hostBoxStyle.BorderStyle);

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.utils.cs
@@ -130,7 +130,7 @@ public sealed partial class PreviewWindow
         var localHostBounds = LayoutHelper.GetHostBounds(previewLayout.CanvasLayout.CanvasBounds.OuterBounds, hostBoxStyle)
             .MoveTo(new PointInfo(0, 0));
 
-        using var borderBitmap = DrawingHelper.RenderBorder(localHostBounds, hostBoxStyle);
+        using var borderBitmap = DrawingHelper.RenderBorder(localHostBounds.BorderBounds.Size, hostBoxStyle.BorderStyle);
 
         await this.InvokeOnUiThreadAsync(
             () =>
@@ -142,9 +142,9 @@ public sealed partial class PreviewWindow
 
                 // position PreviewPane so it lines up exactly with the transparent hole in
                 // the middle of the border image - the offset is always the host box's own
-                // margin+border thickness, regardless of where localHostBounds itself sits.
-                var offsetX = (localHostBounds.ContentBounds.X - localHostBounds.OuterBounds.X) * (decimal)highDpiScalingRatio;
-                var offsetY = (localHostBounds.ContentBounds.Y - localHostBounds.OuterBounds.Y) * (decimal)highDpiScalingRatio;
+                // border thickness, regardless of where localHostBounds itself sits.
+                var offsetX = (localHostBounds.ContentBounds.X - localHostBounds.BorderBounds.X) * (decimal)highDpiScalingRatio;
+                var offsetY = (localHostBounds.ContentBounds.Y - localHostBounds.BorderBounds.Y) * (decimal)highDpiScalingRatio;
                 this.PreviewPane.Margin = new Thickness((double)offsetX, (double)offsetY, 0, 0);
             }).ConfigureAwait(false);
 

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
@@ -48,7 +48,7 @@ public sealed partial class PreviewWindow
         // (in case the user moves it a few pixels while the form is rendered)
         var activatedLocation = MouseHelper.GetCursorPosition();
 
-        var appSettings = ConfigHelper.AppSettings ?? throw new InvalidOperationException();
+        var appSettings = this.ConfigHelper.AppSettings ?? throw new InvalidOperationException();
 
         DisplayInfo displayInfo;
         using (Telemetry.Current.BeginTimer(new { }, "GetDisplayInfo"))

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
@@ -65,16 +65,16 @@ public sealed partial class PreviewWindow
             previewLayout = LayoutHelper.GetPreviewLayout(
                 previewStyle,
                 displayInfo,
-                activatedScreen: activatedScreen);
+                maximumSize: activatedScreen.DisplayArea.Size);
         }
 
         // the outer border is this window's own responsibility, not the preview pane's -
-        // see LayoutHelper.GetHostBoxStyle. PreviewLayout itself has no desktop position
+        // see LayoutHelper.GetPreviewWindowStyle. PreviewLayout itself has no desktop position
         // (only a size - see PreviewLayout), so positioning the window on the desktop -
         // centered on the activated location, clamped to the activated screen - is entirely
         // this window's own job too.
-        var hostBoxStyle = LayoutHelper.GetHostBoxStyle(previewStyle.CanvasStyle);
-        var hostBounds = LayoutHelper.GetHostBounds(new RectangleInfo(previewLayout.PreviewSize), hostBoxStyle);
+        var previewWindowStyle = LayoutHelper.GetPreviewWindowStyle(previewStyle.CanvasStyle);
+        var hostBounds = LayoutHelper.GetPreviewWindowBounds(new RectangleInfo(previewLayout.PreviewSize), previewWindowStyle);
         var positionedHostOuterBounds = LayoutHelper.PositionOnScreen(hostBounds.OuterBounds, activatedScreen, activatedLocation);
 
         // a newer activation superseding this one is the common, expected case under rapid
@@ -91,7 +91,7 @@ public sealed partial class PreviewWindow
         (int Width, int Height, int CornerRadius) windowRegion;
         using (Telemetry.Current.BeginTimer(new { }, "RenderBorderAsync"))
         {
-            windowRegion = await this.RenderBorderAsync(previewLayout, hostBoxStyle)
+            windowRegion = await this.RenderBorderAsync(previewLayout, previewWindowStyle)
                 .ConfigureAwait(false);
         }
 

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.window.cs
@@ -117,7 +117,7 @@ public sealed partial class PreviewWindow
 
         var pipeline = new ScreenshotCapturePipeline(new PreviewPaneScreenshotSink(this), cancellation.Token);
 
-        // one capture provider per device - see IScreenshotCaptureProvider/
+        // create one capture provider per device - see IScreenshotCaptureProvider/
         // DesktopScreenshotCaptureProvider remarks for why a single instance is safe (and
         // necessary) to share across all of that device's screens. Ownership of each provider
         // transfers to the pipeline - see ScreenshotCapturePipeline.DisposeAsync.
@@ -131,11 +131,10 @@ public sealed partial class PreviewWindow
             }
         }
 
-        // the activated screen's own capture must complete before the window is shown,
+        // the activated screen's capture must complete before the window is shown,
         // otherwise a *later* capture of that screen would risk capturing the preview window
         // itself, since it's positioned on top of the activated screen. We only need the
-        // capture itself to be done here, not for it to have reached the PreviewPane yet - the
-        // pipeline pushes every result to the pane independently, in the background.
+        // capture itself to be done here, not the full initialisation of that screen's controls.
         var activatedCaptureTask = captureTasks
             .Single(entry => object.ReferenceEquals(entry.ScreenLayout.ScreenInfo, activatedScreen))
             .CaptureTask;
@@ -144,12 +143,10 @@ public sealed partial class PreviewWindow
         {
             // give every screen up to ScreenshotGracePeriod to finish capturing before
             // showing the window - a typical (fast, local) activation finishes well within
-            // that and shows fully populated, with none of the placeholder-then-backfill
-            // repainting a reader would otherwise see. A screen that's still slow after that
-            // (e.g. a future remote capture provider) doesn't hold the window hostage though
-            // - it just backfills afterwards, same as it would have anyway. The activated
-            // screen's own capture is still awaited separately below regardless of which way
-            // the race went, since that one's non-negotiable (see above).
+            // that and shows fully populated, and a screen whose capture is still executing
+            // will have either a blank background image or a blurred version of the previous
+            // screenshot shown instead until the capture is ready, at which point the screen's
+            // image is automatically updated.
             var allCaptureTasks = captureTasks.Select(entry => entry.CaptureTask).ToArray();
             using (Telemetry.Current.BeginTimer(new { }, "gracePeriodRace"))
             {
@@ -226,12 +223,8 @@ public sealed partial class PreviewWindow
     }
 
     /// <summary>
-    /// Reveals the window by swapping its clip region from empty (see <see cref="HideWindow"/>) to
-    /// <paramref name="width"/> x <paramref name="height"/> with corner radius
-    /// <paramref name="cornerRadius"/> - the same values <see cref="RenderBorderAsync"/> rendered
-    /// against, passed back in here rather than reapplied as part of that method, so the region
-    /// only ever shows real, fully-built content instead of becoming visible partway through
-    /// rendering it.
+    /// Shows the window by swapping its clip region from empty (see <see cref="HideWindow"/>) to
+    /// <paramref name="width"/> x <paramref name="height"/> with a curved corner mask.
     /// </summary>
     private async Task ShowWindowAsync(int width, int height, int cornerRadius, CancellationToken cancellationToken)
     {

--- a/src/FancyMouse.WinUI3/UI/PreviewWindow.xaml.cs
+++ b/src/FancyMouse.WinUI3/UI/PreviewWindow.xaml.cs
@@ -1,4 +1,5 @@
 using FancyMouse.Common.Capture;
+using FancyMouse.WinUI3.Internal.Helpers;
 
 using Microsoft.UI.Xaml;
 
@@ -11,14 +12,20 @@ namespace FancyMouse.WinUI3.UI;
 /// </summary>
 public sealed partial class PreviewWindow : Window
 {
-    public PreviewWindow(NLog.ILogger logger)
+    internal PreviewWindow(NLog.ILogger logger, ConfigHelper configHelper)
     {
         this.Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.ConfigHelper = configHelper ?? throw new ArgumentNullException(nameof(configHelper));
         this.InitializeComponent();
         this.InitializeWindow();
     }
 
     private NLog.ILogger Logger
+    {
+        get;
+    }
+
+    private ConfigHelper ConfigHelper
     {
         get;
     }

--- a/src/FancyMouse.sln
+++ b/src/FancyMouse.sln
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{EF72E2
 		Common.Dotnet.Analyzers.props = Common.Dotnet.Analyzers.props
 		Common.Dotnet.CsWin32.props = Common.Dotnet.CsWin32.props
 		Common.Dotnet.CsWinRT.props = Common.Dotnet.CsWinRT.props
+		Common.Dotnet.props = Common.Dotnet.props
 		Common.SelfContained.props = Common.SelfContained.props
 		..\Directory.Build.props = ..\Directory.Build.props
 	EndProjectSection


### PR DESCRIPTION
General maintenance - a bunch of method renaming, comment edits, 

**Bezel rendering (`DrawingHelper.cs`)**
- ```RenderBackground``` / ```RenderBorder``` made box-model-agnostic - now take ```(SizeInfo, BackgroundStyle/BorderStyle)``` instead of ```(CanvasLayout)``` / ```(BoxBounds, BoxStyle)```
- ```DrawBackgroundFill```, ```GetBackgroundStyleBrush```, and ```DrawRaisedBorder``` all inlined and removed

**Layout helper (`LayoutHelper.cs`)**
- ```GetPreviewLayout``` parameter changed from ```ScreenInfo activatedScreen``` to ```SizeInfo? maximumSize = null``` to allow unbounded preview layouts (fixes downstream https://github.com/microsoft/PowerToys/issues/50436)
- ```GetHostBoxStyle``` → ```GetPreviewWindowStyle```, ```GetPreviewBoxStyle``` → ```GetPreviewPaneStyle```, ```GetHostBounds``` → ```GetPreviewWindowBounds```
- ```CreateInitialPreviewLayout``` split some functionality off into ```AddDeviceAndScreenStyles``
- ```GetDeviceScreenStyles``` inlined at single call site

**Config / settings handling**
- ```ConfigHelper``` converted from a static class to an instance class (`ConfigHelper(NLog.ILogger logger)`), now implementing `IDisposable`; threaded through `App.xaml.cs` and `PreviewWindow` as a constructor parameter/property instead of static calls
- `ConfigHelper.OnAppSettingsChanged`' -  error logging switched from ```Console.WriteLine``` to ```NLog.ILogger```, ```JsonException``` from a malformed live-edit is now caught separately
- ```AppSettingsReader.ParseJson``` - no longer swallows JSON parse failures into silent default-settings, throws instead)
- Fixed ```HotKeyManager.SetHoKey``` typo (```SetHotKey```)

**Tests**
- added ```BezelProfileTests.cs``` and ```BezelRendererTests.cs```

<img width="1600" height="357" alt="image" src="https://github.com/user-attachments/assets/76188a59-eb67-4ec5-add5-bc660e8d08af" />
